### PR TITLE
Use scratch fork of paper

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^15"
   },
   "devDependencies": {
+    "@scratch/paper": "~0.11.6",
     "autoprefixer": "7.1.2",
     "babel-cli": "6.26.0",
     "babel-core": "^6.23.1",

--- a/src/containers/blob/blob.js
+++ b/src/containers/blob/blob.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 import log from '../../log/log';
 import BroadBrushHelper from './broad-brush-helper';
 import SegmentBrushHelper from './segment-brush-helper';

--- a/src/containers/blob/broad-brush-helper.js
+++ b/src/containers/blob/broad-brush-helper.js
@@ -1,5 +1,5 @@
 // Broadbrush based on http://paperjs.org/tutorials/interaction/working-with-mouse-vectors/
-import paper from 'paper';
+import paper from '@scratch/paper';
 import {stylePath} from '../../helper/style-path';
 
 /**

--- a/src/containers/blob/segment-brush-helper.js
+++ b/src/containers/blob/segment-brush-helper.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 import {stylePath} from '../../helper/style-path';
 
 /**

--- a/src/containers/line-mode.jsx
+++ b/src/containers/line-mode.jsx
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';

--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -11,7 +11,7 @@ import {performUndo, performRedo, performSnapshot} from '../helper/undo';
 import Modes from '../modes/modes';
 import {connect} from 'react-redux';
 import bindAll from 'lodash.bindall';
-import paper from 'paper';
+import paper from '@scratch/paper';
 
 class PaintEditor extends React.Component {
     constructor (props) {

--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -2,7 +2,7 @@ import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import paper from 'paper';
+import paper from '@scratch/paper';
 
 import {performSnapshot} from '../helper/undo';
 import {undoSnapshot} from '../reducers/undo';

--- a/src/containers/selection-hoc.jsx
+++ b/src/containers/selection-hoc.jsx
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/helper/group.js
+++ b/src/helper/group.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 import {getRootItem, isGroupItem} from './item';
 import {clearSelection, getSelectedRootItems, setItemSelection} from './selection';
 

--- a/src/helper/guides.js
+++ b/src/helper/guides.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 import {getGuideLayer} from './layer';
 import {getAllRootItems} from './selection';
 

--- a/src/helper/hover.js
+++ b/src/helper/hover.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 import {isBoundsItem, getRootItem} from './item';
 import {hoverBounds, hoverItem} from './guides';
 import {isGroupChild} from './group';

--- a/src/helper/item.js
+++ b/src/helper/item.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 
 const getRootItem = function (item) {
     if (item.parent.className === 'Layer') {

--- a/src/helper/layer.js
+++ b/src/helper/layer.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 
 const getGuideLayer = function () {
     for (let i = 0; i < paper.project.layers.length; i++) {

--- a/src/helper/math.js
+++ b/src/helper/math.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 
 const checkPointsClose = function (startPos, eventPoint, threshold) {
     const xOff = Math.abs(startPos.x - eventPoint.x);

--- a/src/helper/selection-tools/bounding-box-tool.js
+++ b/src/helper/selection-tools/bounding-box-tool.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 import keyMirror from 'keymirror';
 
 import {getSelectedRootItems} from '../selection';

--- a/src/helper/selection-tools/point-tool.js
+++ b/src/helper/selection-tools/point-tool.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 import {snapDeltaToAngle} from '../math';
 import {clearSelection, getSelectedLeafItems} from '../selection';
 

--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 import log from '../../log/log';
 import keyMirror from 'keymirror';
 

--- a/src/helper/selection-tools/rotate-tool.js
+++ b/src/helper/selection-tools/rotate-tool.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 
 /**
  * Tool to handle rotation when dragging the rotation handle in the bounding box tool.

--- a/src/helper/selection-tools/scale-tool.js
+++ b/src/helper/selection-tools/scale-tool.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 
 /**
  * Tool to handle scaling items by pulling on the handles around the edges of the bounding

--- a/src/helper/selection-tools/select-tool.js
+++ b/src/helper/selection-tools/select-tool.js
@@ -4,7 +4,7 @@ import {getHoveredItem} from '../hover';
 import {deleteSelection, selectRootItem} from '../selection';
 import BoundingBoxTool from './bounding-box-tool';
 import SelectionBoxTool from './selection-box-tool';
-import paper from 'paper';
+import paper from '@scratch/paper';
 
 /**
  * paper.Tool that handles select mode. This is made up of 2 subtools.

--- a/src/helper/selection.js
+++ b/src/helper/selection.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 import Modes from '../modes/modes';
 
 import {getItemsGroup, isGroup} from './group';

--- a/src/helper/style-path.js
+++ b/src/helper/style-path.js
@@ -1,4 +1,4 @@
-import paper from 'paper';
+import paper from '@scratch/paper';
 import {getSelectedLeafItems} from './selection';
 import {isPGTextItem, isPointTextItem} from './item';
 import {isGroup} from './group';

--- a/src/helper/undo.js
+++ b/src/helper/undo.js
@@ -1,6 +1,6 @@
 // undo functionality
 // modifed from https://github.com/memononen/stylii
-import paper from 'paper';
+import paper from '@scratch/paper';
 
 const performSnapshot = function (dispatchPerformSnapshot) {
     dispatchPerformSnapshot({


### PR DESCRIPTION
Switch to a fork of paper.js that's customized to have our own selection style.

Ideally we will only depend on this fork temporarily. We should be able to use paper.js again after paperjs/paper.js#1380 , which might take awhile