### PR TITLE
Don't hit test against handles that aren't showing

### DIFF
--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -96,6 +96,10 @@ class ReshapeTool extends paper.Tool {
                     if (!item.segment.selected) {
                         return false;
                     }
+                    // If the entire shape is selected, handles are hidden
+                    if (item.item.fullySelected) {
+                        return false;
+                    }
                 }
                 return true;
             };
@@ -105,6 +109,10 @@ class ReshapeTool extends paper.Tool {
                     // Only hit test against handles that are visible, that is,
                     // their segment is selected
                     if (!item.segment.selected) {
+                        return false;
+                    }
+                    // If the entire shape is selected, handles are hidden
+                    if (item.item.fullySelected) {
                         return false;
                     }
                 }


### PR DESCRIPTION
Add back caveats for fully selected shapes, since code to remove handles when a shape is fully selected is in the paper fork we are using.

Basically, if an object has all points selected, don't show the handles on every point, and make the handles not-selectable.

We may need to remove this again if we switch to using the official paper fork.