### PR TITLE
Fix a bunch of things around import and export

### DIFF
--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -29,8 +29,9 @@ class PaintEditor extends React.Component {
         document.removeEventListener('keydown', this.props.onKeyPress);
     }
     handleUpdateSvg (skipSnapshot) {
-        // Hide bounding box
-        getGuideLayer().visible = false;
+        // Hide guide layer
+        const guideLayer = getGuideLayer();
+        guideLayer.remove();
         const bounds = paper.project.activeLayer.bounds;
         this.props.onUpdateSvg(
             paper.project.exportSVG({
@@ -42,7 +43,7 @@ class PaintEditor extends React.Component {
         if (!skipSnapshot) {
             performSnapshot(this.props.undoSnapshot);
         }
-        getGuideLayer().visible = true;
+        paper.project.addLayer(guideLayer);
     }
     handleUndo () {
         performUndo(this.props.undoState, this.props.onUndo, this.handleUpdateSvg);


### PR DESCRIPTION
- Remove instead of hiding the guide layer. Having multiple layers causes paper.js to convert each layer into a group when exporting SVGs, even though the layer is hidden, which causes costumes to get nested into groups.
- Take an undo snapshot after each SVG import. If you change costumes, you won't be able to undo back into the other costumes' undo stack.
- If you import a sprite that's a group, ungroup it so it starts off looking editable. (This required some change in the ungroup logic in order to not select everything after it was ungrouped)
