### PR TITLE
Line tool snapping

### DIFF
--- a/src/containers/line-mode.jsx
+++ b/src/containers/line-mode.jsx
@@ -81,9 +81,10 @@ class LineMode extends React.Component {
             if (this.hitResult.isFirst) {
                 this.path.reverse();
             }
+
+            this.path.lastSegment.handleOut = null; // Make sure added line isn't made curvy
+            this.path.lastSegment.handleIn = null; // Bug in paper.js? You need to remove the other handle too
             this.path.add(this.hitResult.segment); // Add second point, which is what will move when dragged
-            this.path.lastSegment.handleOut = null; // Make sure line isn't curvy
-            this.path.lastSegment.handleIn = null;
         }
 
         // If not near other path, start a new path
@@ -164,11 +165,11 @@ class LineMode extends React.Component {
             this.path = null;
             return;
         }
-        
         // If I intersect other line end points, join or close
         if (this.hitResult) {
             this.path.removeSegment(this.path.segments.length - 1);
             if (this.path.firstSegment.point.equals(this.hitResult.segment.point)) {
+                this.path.firstSegment.handleIn = null; // Make sure added line isn't made curvy
                 // close path
                 this.path.closed = true;
             } else {
@@ -176,6 +177,7 @@ class LineMode extends React.Component {
                 if (!this.hitResult.isFirst) {
                     this.hitResult.path.reverse();
                 }
+                this.hitResult.path.firstSegment.handleIn = null; // Make sure added line isn't made curvy
                 this.path.join(this.hitResult.path);
             }
             removeHitPoint();

--- a/src/containers/line-mode.jsx
+++ b/src/containers/line-mode.jsx
@@ -149,19 +149,17 @@ class LineMode extends React.Component {
         if (event.event.button > 0) return; // only first mouse button
 
         // If I single clicked, don't do anything
-        if (!this.hitResult && // Might be connecting 2 points that are very close
-                (this.path.segments.length < 2 ||
-                    (this.path.segments.length === 2 &&
-                    touching(this.path.firstSegment.point, event.point, LineMode.SNAP_TOLERANCE)))) {
+        if (this.path.segments.length < 2 ||
+                (this.path.segments.length === 2 &&
+                touching(this.path.firstSegment.point, event.point, LineMode.SNAP_TOLERANCE) &&
+                !this.hitResult)) { // Let lines be short if you're connecting them
             this.path.remove();
             this.path = null;
             return;
-        } else if (
-            // Single click on an existing path end point
-            touching(
-                this.path.lastSegment.point,
-                this.path.segments[this.path.segments.length - 2].point,
-                LineMode.SNAP_TOLERANCE)) {
+        } else if (!this.hitResult &&
+                touching(this.path.lastSegment.point, this.path.segments[this.path.segments.length - 2].point,
+                    LineMode.SNAP_TOLERANCE)) {
+            // Single click or short drag on an existing path end point
             this.path.removeSegment(this.path.segments.length - 1);
             this.path = null;
             return;

--- a/src/containers/line-mode.jsx
+++ b/src/containers/line-mode.jsx
@@ -83,8 +83,7 @@ class LineMode extends React.Component {
             }
 
             this.path.lastSegment.handleOut = null; // Make sure added line isn't made curvy
-            this.path.lastSegment.handleIn = null; // Bug in paper.js? You need to remove the other handle too
-            this.path.add(this.hitResult.segment); // Add second point, which is what will move when dragged
+            this.path.add(this.hitResult.segment.point); // Add second point, which is what will move when dragged
         }
 
         // If not near other path, start a new path

--- a/src/helper/blob-tools/broad-brush-helper.js
+++ b/src/helper/blob-tools/broad-brush-helper.js
@@ -1,6 +1,6 @@
 // Broadbrush based on http://paperjs.org/tutorials/interaction/working-with-mouse-vectors/
 import paper from '@scratch/paper';
-import {stylePath} from '../../helper/style-path';
+import {styleBlob} from '../../helper/style-path';
 
 /**
  * Broad brush functions to add as listeners on the mouse. Call them when the corresponding mouse event happens
@@ -25,7 +25,7 @@ class BroadBrushHelper {
         if (event.event.button > 0) return; // only first mouse button
         
         this.finalPath = new paper.Path();
-        stylePath(this.finalPath, options);
+        styleBlob(this.finalPath, options);
         this.finalPath.add(event.point);
         this.lastPoint = this.secondLastPoint = event.point;
     }
@@ -77,7 +77,7 @@ class BroadBrushHelper {
                 center: event.point,
                 radius: options.brushSize / 2
             });
-            stylePath(this.finalPath, options);
+            styleBlob(this.finalPath, options);
         } else {
             const step = (event.point.subtract(this.lastPoint)).normalize(options.brushSize / 2);
             step.angle += 90;

--- a/src/helper/blob-tools/segment-brush-helper.js
+++ b/src/helper/blob-tools/segment-brush-helper.js
@@ -1,5 +1,5 @@
 import paper from '@scratch/paper';
-import {stylePath} from '../../helper/style-path';
+import {styleBlob} from '../../helper/style-path';
 
 /**
  * Segment brush functions to add as listeners on the mouse. Call them when the corresponding mouse event happens
@@ -32,7 +32,7 @@ class SegmentBrushHelper {
             radius: options.brushSize / 2
         });
         this.finalPath = this.firstCircle;
-        stylePath(this.finalPath, options);
+        styleBlob(this.finalPath, options);
         this.lastPoint = event.point;
     }
     
@@ -46,7 +46,7 @@ class SegmentBrushHelper {
 
         const path = new paper.Path();
         
-        stylePath(path, options);
+        styleBlob(path, options);
 
         // Add handles to round the end caps
         path.add(new paper.Segment(this.lastPoint.subtract(step), handleVec.multiply(-1), handleVec));

--- a/src/helper/guides.js
+++ b/src/helper/guides.js
@@ -58,12 +58,8 @@ const rectSelect = function (event, color) {
     return rect;
 };
 
-const getGuideColor = function (colorName) {
-    if (colorName === 'blue') {
-        return GUIDE_BLUE;
-    } else if (colorName === 'grey') {
-        return GUIDE_GREY;
-    }
+const getGuideColor = function () {
+    return GUIDE_BLUE;
 };
 
 const _removePaperItemsByDataTags = function (tags) {
@@ -96,12 +92,30 @@ const removeAllGuides = function () {
     _removePaperItemsByTags(['guide']);
 };
 
+const removeHitPoint = function () {
+    _removePaperItemsByDataTags(['isHitPoint']);
+};
+
+const drawHitPoint = function (point) {
+    removeHitPoint();
+    if (point) {
+        const hitPoint = paper.Path.Circle(point, 4 /* radius */);
+        hitPoint.strokeColor = GUIDE_BLUE;
+        hitPoint.fillColor = new paper.Color(1, 1, 1, 0.5);
+        hitPoint.parent = getGuideLayer();
+        hitPoint.data.isHitPoint = true;
+        hitPoint.data.isHelperItem = true;
+    }
+};
+
 export {
     hoverItem,
     hoverBounds,
     rectSelect,
     removeAllGuides,
     removeHelperItems,
+    drawHitPoint,
+    removeHitPoint,
     getGuideColor,
     setDefaultGuideStyle
 };

--- a/src/helper/selection-tools/bounding-box-tool.js
+++ b/src/helper/selection-tools/bounding-box-tool.js
@@ -170,7 +170,7 @@ class BoundingBoxTool {
                     noSelect: true,
                     noHover: true
                 };
-                rotHandle.fillColor = getGuideColor('blue');
+                rotHandle.fillColor = getGuideColor();
                 rotHandle.parent = getGuideLayer();
                 this.boundsRotHandles[index] = rotHandle;
             }
@@ -186,7 +186,7 @@ class BoundingBoxTool {
                         noHover: true
                     },
                     size: [size / paper.view.zoom, size / paper.view.zoom],
-                    fillColor: getGuideColor('blue'),
+                    fillColor: getGuideColor(),
                     parent: getGuideLayer()
                 });
         }

--- a/src/helper/snapping.js
+++ b/src/helper/snapping.js
@@ -1,0 +1,58 @@
+import paper from '@scratch/paper';
+
+/**
+ * @param {paper.Point} point1 point 1
+ * @param {paper.Point} point2 point 2
+ * @param {number} tolerance Distance allowed between points that are "touching"
+ * @return {boolean} true if points are within the tolerance distance.
+ */
+const touching = function (point1, point2, tolerance) {
+    return point1.getDistance(point2, true) < Math.pow(tolerance / paper.view.zoom, 2);
+};
+
+/**
+ * @param {!paper.Point} point Point to check line endpoint hits against
+ * @param {!number} tolerance Distance within which it counts as a hit
+ * @param {?paper.Path} excludePath Path to exclude from hit test, if any. For instance, you
+ *     are drawing a line and don't want it to snap to its own start point.
+ * @return {object} data about the end point of an unclosed path, if any such point is within the
+ *     tolerance distance of the given point, or null if none exists.
+ */
+const endPointHit = function (point, tolerance, excludePath) {
+    const lines = paper.project.getItems({
+        class: paper.Path
+    });
+    // Prefer more recent lines
+    for (let i = lines.length - 1; i >= 0; i--) {
+        if (lines[i].closed) {
+            continue;
+        }
+        if (!(lines[i].parent instanceof paper.Layer)) {
+            // Don't connect to lines inside of groups
+            continue;
+        }
+        if (excludePath && lines[i] === excludePath) {
+            continue;
+        }
+        if (lines[i].firstSegment && touching(lines[i].firstSegment.point, point, tolerance)) {
+            return {
+                path: lines[i],
+                segment: lines[i].firstSegment,
+                isFirst: true
+            };
+        }
+        if (lines[i].lastSegment && touching(lines[i].lastSegment.point, point, tolerance)) {
+            return {
+                path: lines[i],
+                segment: lines[i].lastSegment,
+                isFirst: false
+            };
+        }
+    }
+    return null;
+};
+
+export {
+    endPointHit,
+    touching
+};

--- a/src/helper/style-path.js
+++ b/src/helper/style-path.js
@@ -198,7 +198,7 @@ const getColorsFromSelection = function (selectedItems) {
     };
 };
 
-const stylePath = function (path, options) {
+const styleBlob = function (path, options) {
     if (options.isEraser) {
         path.fillColor = 'white';
     } else if (options.fillColor) {
@@ -207,6 +207,14 @@ const stylePath = function (path, options) {
         // Make sure something visible is drawn
         path.fillColor = 'black';
     }
+};
+
+const stylePath = function (path, strokeColor, strokeWidth) {
+    // Make sure a visible line is drawn
+    path.setStrokeColor(
+        (strokeColor === MIXED || strokeColor === null) ? 'black' : strokeColor);
+    path.setStrokeWidth(
+        strokeWidth === null || strokeWidth === 0 ? 1 : strokeWidth);
 };
 
 const styleCursorPreview = function (path, options) {
@@ -228,6 +236,7 @@ export {
     applyStrokeWidthToSelection,
     getColorsFromSelection,
     MIXED,
+    styleBlob,
     stylePath,
     styleCursorPreview
 };


### PR DESCRIPTION
When lines snap together, they were using selection state to indicate snapping. However, selection state now determines the state of the color pickers, and we don't want colors to start changing around based on snapping suggestions. So I've switched line tool snapping to draw a guide instead of using selection.

In addition, I've moved shared functions between line and pen tool into helper functions in preparation for adding the pen tool.

![snapping](https://user-images.githubusercontent.com/2855464/31776253-029aeada-b4b9-11e7-9afd-d52372db961b.gif)
