### PR TITLE
Allow erase through groups

### DIFF
--- a/src/helper/blob-tools/blob.js
+++ b/src/helper/blob-tools/blob.js
@@ -195,7 +195,8 @@ class Blobbiness {
         // Get all path items to merge with
         const paths = paper.project.getItems({
             match: function (item) {
-                return blob.isMergeable(lastPath, item);
+                return blob.isMergeable(lastPath, item) &&
+                    item.parent instanceof paper.Layer; // don't merge with nested in group
             }
         });
 
@@ -390,8 +391,7 @@ class Blobbiness {
     isMergeable (newPath, existingPath) {
         return existingPath instanceof paper.PathItem && // path or compound path
             existingPath !== this.cursorPreview && // don't merge with the mouse preview
-            existingPath !== newPath && // don't merge with self
-            existingPath.parent instanceof paper.Layer; // don't merge with nested in group
+            existingPath !== newPath; // don't merge with self
     }
 
     deactivateTool () {


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/60

![eraser](https://user-images.githubusercontent.com/2855464/31780175-f5a5d038-b4c2-11e7-9517-fa86ea1b996d.gif)

Erasing used to only affect shapes that weren't grouped, but now it can also erase shapes in groups.