### PR TITLE
Add props for name, onUpdateName, and svgId

### DIFF
--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -54,7 +54,8 @@ class PaintEditorComponent extends React.Component {
                         <Label text={this.props.intl.formatMessage(messages.costume)}>
                             <BufferedInput
                                 type="text"
-                                value="meow"
+                                value={this.props.name}
+                                onSubmit={this.props.onUpdateName}
                             />
                         </Label>
                     </div>
@@ -178,8 +179,10 @@ class PaintEditorComponent extends React.Component {
 
 PaintEditorComponent.propTypes = {
     intl: intlShape,
+    name: PropTypes.string,
     onRedo: PropTypes.func.isRequired,
     onUndo: PropTypes.func.isRequired,
+    onUpdateName: PropTypes.func.isRequired,
     onUpdateSvg: PropTypes.func.isRequired,
     rotationCenterX: PropTypes.number,
     rotationCenterY: PropTypes.number,

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -169,6 +169,7 @@ class PaintEditorComponent extends React.Component {
                             rotationCenterX={this.props.rotationCenterX}
                             rotationCenterY={this.props.rotationCenterY}
                             svg={this.props.svg}
+                            svgId={this.props.svgId}
                         />
                     </div>
                 </div>
@@ -186,7 +187,8 @@ PaintEditorComponent.propTypes = {
     onUpdateSvg: PropTypes.func.isRequired,
     rotationCenterX: PropTypes.number,
     rotationCenterY: PropTypes.number,
-    svg: PropTypes.string
+    svg: PropTypes.string,
+    svgId: PropTypes.string
 };
 
 export default injectIntl(PaintEditorComponent);

--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -54,11 +54,13 @@ class PaintEditor extends React.Component {
     render () {
         return (
             <PaintEditorComponent
+                name={this.props.name}
                 rotationCenterX={this.props.rotationCenterX}
                 rotationCenterY={this.props.rotationCenterY}
                 svg={this.props.svg}
                 onRedo={this.handleRedo}
                 onUndo={this.handleUndo}
+                onUpdateName={this.props.onUpdateName}
                 onUpdateSvg={this.handleUpdateSvg}
             />
         );
@@ -66,9 +68,11 @@ class PaintEditor extends React.Component {
 }
 
 PaintEditor.propTypes = {
+    name: PropTypes.string,
     onKeyPress: PropTypes.func.isRequired,
     onRedo: PropTypes.func.isRequired,
     onUndo: PropTypes.func.isRequired,
+    onUpdateName: PropTypes.func.isRequired,
     onUpdateSvg: PropTypes.func.isRequired,
     rotationCenterX: PropTypes.number,
     rotationCenterY: PropTypes.number,

--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -58,6 +58,7 @@ class PaintEditor extends React.Component {
                 rotationCenterX={this.props.rotationCenterX}
                 rotationCenterY={this.props.rotationCenterY}
                 svg={this.props.svg}
+                svgId={this.props.svgId}
                 onRedo={this.handleRedo}
                 onUndo={this.handleUndo}
                 onUpdateName={this.props.onUpdateName}
@@ -77,6 +78,7 @@ PaintEditor.propTypes = {
     rotationCenterX: PropTypes.number,
     rotationCenterY: PropTypes.number,
     svg: PropTypes.string,
+    svgId: PropTypes.string,
     undoSnapshot: PropTypes.func.isRequired,
     undoState: PropTypes.shape({
         stack: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -29,6 +29,7 @@ class PaperCanvas extends React.Component {
         }
     }
     componentWillReceiveProps (newProps) {
+        if (this.props.svgId === newProps.svgId) return;
         for (const layer of paper.project.layers) {
             layer.removeChildren();
         }
@@ -108,6 +109,7 @@ PaperCanvas.propTypes = {
     rotationCenterX: PropTypes.number,
     rotationCenterY: PropTypes.number,
     svg: PropTypes.string,
+    svgId: PropTypes.string,
     undoSnapshot: PropTypes.func.isRequired
 };
 const mapDispatchToProps = dispatch => ({

--- a/src/playground/playground.jsx
+++ b/src/playground/playground.jsx
@@ -49,6 +49,7 @@ class Playground extends React.Component {
         return (
             <PaintEditor
                 {...this.state}
+                svgId="meow"
                 onUpdateName={this.handleUpdateName}
                 onUpdateSvg={this.handleUpdateSvg}
             />

--- a/src/playground/playground.jsx
+++ b/src/playground/playground.jsx
@@ -1,3 +1,4 @@
+import bindAll from 'lodash.bindall';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PaintEditor from '..';
@@ -22,19 +23,43 @@ const svgString =
         '<polyline points="10.689,399.492 3.193,391.997 10.689,384.5 "/>' +
         '<polyline points="30.185,405.995 22.689,413.491 15.192,405.995 "/>' +
     '</svg>';
-const onUpdateSvg = function (newSvgString, rotationCenterX, rotationCenterY) {
-    console.log(newSvgString);
-    console.log(`rotationCenterX: ${rotationCenterX}    rotationCenterY: ${rotationCenterY}`);
-};
+class Playground extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'handleUpdateName',
+            'handleUpdateSvg'
+        ]);
+        this.state = {
+            name: 'meow',
+            rotationCenterX: 0,
+            rotationCenterY: 0,
+            svg: svgString
+        };
+    }
+    handleUpdateName (name) {
+        this.setState({name});
+    }
+    handleUpdateSvg (svg, rotationCenterX, rotationCenterY) {
+        console.log(svg);
+        console.log(`rotationCenterX: ${rotationCenterX}    rotationCenterY: ${rotationCenterY}`);
+        this.setState({svg, rotationCenterX, rotationCenterY});
+    }
+    render () {
+        return (
+            <PaintEditor
+                {...this.state}
+                onUpdateName={this.handleUpdateName}
+                onUpdateSvg={this.handleUpdateSvg}
+            />
+        );
+    }
+
+}
 ReactDOM.render((
     <Provider store={store}>
         <IntlProvider>
-            <PaintEditor
-                rotationCenterX={0}
-                rotationCenterY={0}
-                svg={svgString}
-                onUpdateSvg={onUpdateSvg}
-            />
+            <Playground />
         </IntlProvider>
     </Provider>
 ), appTarget);


### PR DESCRIPTION
Adds new props for the PaintEditor component so that the costume name can be updated. Update the playground to account for these.

With this change, also only reset undo state when `svgId` changes, not the `svg` prop.