### PR TITLE
Fix GH-83: Move paint-specific styling out of button

### DIFF
--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -1,22 +1,3 @@
-$border-radius: .25rem;
-
 .button {
-    padding: 0.25rem;
-    outline: none;
-    background: white;
-    border-radius: $border-radius;
-    border: 1px solid #ddd;
     cursor: pointer;
-    font-size: 0.85rem;
-    transition: 0.2s;
-}
-
-.button > img {
-    flex-grow: 1;
-    width: 1.5rem;
-    height: 1.5rem;
-}
-
-.button:disabled > img {
-    opacity: 0.25;
 }

--- a/src/components/tool-select-base/tool-select-base.css
+++ b/src/components/tool-select-base/tool-select-base.css
@@ -1,8 +1,16 @@
 @import '../../css/colors.css';
 
+$border-radius: .25rem;
+
 .tool-select {
-    background: none;
+    display: inline-block;
     border: none;
+    border-radius: $border-radius;
+    outline: none;
+    background: none;
+    padding: 0.25rem;
+    font-size: 0.85rem;
+    transition: 0.2s;
 }
 
 .tool-select.is-selected {
@@ -16,4 +24,6 @@
 img.tool-select-icon {
     width: 2rem;
     height: 2rem;
+    flex-grow: 1;
+    vertical-align: middle;
 }


### PR DESCRIPTION
Fixes #83 by making sure the copied-over button component has the same styling as in gui too, and move specifics to composing components