### PR TITLE
Add group/ungroup

### DIFF
--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -150,14 +150,14 @@ class PaintEditorComponent extends React.Component {
                         </InputGroup>
 
                         {/* To be rotation point */}
-                        <InputGroup>
+                        {/* <InputGroup>
                             <EditFieldButton
                                 imgAlt="Rotation Point Icon"
                                 imgSrc={rotationPointIcon}
                                 title="Rotation Point"
                                 onClick={function () {}}
                             />
-                        </InputGroup>
+                        </InputGroup> */}
                     </div>
 
                     {/* Second Row */}

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -113,7 +113,7 @@ class PaintEditorComponent extends React.Component {
                                 imgAlt="Ungroup Icon"
                                 imgSrc={ungroupIcon}
                                 title="Ungroup"
-                                onClick={function () {}}
+                                onClick={this.props.onUngroup}
                             />
                         </InputGroup>
 

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -101,13 +101,13 @@ class PaintEditorComponent extends React.Component {
                             </ButtonGroup>
                         </InputGroup>
 
-                        {/* To be Group/Ungroup */}
+                        {/* Group/Ungroup */}
                         <InputGroup className={styles.modDashedBorder}>
                             <EditFieldButton
                                 imgAlt="Group Icon"
                                 imgSrc={groupIcon}
                                 title="Group"
-                                onClick={function () {}}
+                                onClick={this.props.onGroup}
                             />
                             <EditFieldButton
                                 imgAlt="Ungroup Icon"
@@ -150,14 +150,14 @@ class PaintEditorComponent extends React.Component {
                         </InputGroup>
 
                         {/* To be rotation point */}
-                        {/* <InputGroup>
+                        <InputGroup>
                             <EditFieldButton
                                 imgAlt="Rotation Point Icon"
                                 imgSrc={rotationPointIcon}
                                 title="Rotation Point"
                                 onClick={function () {}}
                             />
-                        </InputGroup> */}
+                        </InputGroup>
                     </div>
 
                     {/* Second Row */}
@@ -236,12 +236,14 @@ class PaintEditorComponent extends React.Component {
 PaintEditorComponent.propTypes = {
     intl: intlShape,
     name: PropTypes.string,
+    onGroup: PropTypes.func.isRequired,
     onRedo: PropTypes.func.isRequired,
     onSendBackward: PropTypes.func.isRequired,
     onSendForward: PropTypes.func.isRequired,
     onSendToBack: PropTypes.func.isRequired,
     onSendToFront: PropTypes.func.isRequired,
     onUndo: PropTypes.func.isRequired,
+    onUngroup: PropTypes.func.isRequired,
     onUpdateName: PropTypes.func.isRequired,
     onUpdateSvg: PropTypes.func.isRequired,
     rotationCenterX: PropTypes.number,

--- a/src/containers/oval-mode.jsx
+++ b/src/containers/oval-mode.jsx
@@ -1,3 +1,4 @@
+import paper from '@scratch/paper';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
@@ -27,6 +28,9 @@ class OvalMode extends React.Component {
     componentWillReceiveProps (nextProps) {
         if (this.tool && nextProps.colorState !== this.props.colorState) {
             this.tool.setColorState(nextProps.colorState);
+        }
+        if (this.tool && nextProps.selectedItems !== this.props.selectedItems) {
+            this.tool.onSelectionChanged(nextProps.selectedItems);
         }
 
         if (nextProps.isOvalModeActive && !this.props.isOvalModeActive) {
@@ -73,12 +77,14 @@ OvalMode.propTypes = {
     handleMouseDown: PropTypes.func.isRequired,
     isOvalModeActive: PropTypes.bool.isRequired,
     onUpdateSvg: PropTypes.func.isRequired,
+    selectedItems: PropTypes.arrayOf(PropTypes.instanceOf(paper.Item)),
     setSelectedItems: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
     colorState: state.scratchPaint.color,
-    isOvalModeActive: state.scratchPaint.mode === Modes.OVAL
+    isOvalModeActive: state.scratchPaint.mode === Modes.OVAL,
+    selectedItems: state.scratchPaint.selectedItems
 });
 const mapDispatchToProps = dispatch => ({
     clearSelectedItems: () => {
@@ -89,8 +95,6 @@ const mapDispatchToProps = dispatch => ({
     },
     handleMouseDown: () => {
         dispatch(changeMode(Modes.OVAL));
-    },
-    deactivateTool () {
     }
 });
 

--- a/src/containers/rect-mode.jsx
+++ b/src/containers/rect-mode.jsx
@@ -1,3 +1,4 @@
+import paper from '@scratch/paper';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
@@ -27,6 +28,9 @@ class RectMode extends React.Component {
     componentWillReceiveProps (nextProps) {
         if (this.tool && nextProps.colorState !== this.props.colorState) {
             this.tool.setColorState(nextProps.colorState);
+        }
+        if (this.tool && nextProps.selectedItems !== this.props.selectedItems) {
+            this.tool.onSelectionChanged(nextProps.selectedItems);
         }
 
         if (nextProps.isRectModeActive && !this.props.isRectModeActive) {
@@ -73,12 +77,14 @@ RectMode.propTypes = {
     handleMouseDown: PropTypes.func.isRequired,
     isRectModeActive: PropTypes.bool.isRequired,
     onUpdateSvg: PropTypes.func.isRequired,
+    selectedItems: PropTypes.arrayOf(PropTypes.instanceOf(paper.Item)),
     setSelectedItems: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
     colorState: state.scratchPaint.color,
-    isRectModeActive: state.scratchPaint.mode === Modes.RECT
+    isRectModeActive: state.scratchPaint.mode === Modes.RECT,
+    selectedItems: state.scratchPaint.selectedItems
 });
 const mapDispatchToProps = dispatch => ({
     clearSelectedItems: () => {

--- a/src/containers/select-mode.jsx
+++ b/src/containers/select-mode.jsx
@@ -1,3 +1,4 @@
+import paper from '@scratch/paper';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
@@ -28,6 +29,9 @@ class SelectMode extends React.Component {
     componentWillReceiveProps (nextProps) {
         if (this.tool && nextProps.hoveredItemId !== this.props.hoveredItemId) {
             this.tool.setPrevHoveredItemId(nextProps.hoveredItemId);
+        }
+        if (this.tool && nextProps.selectedItems !== this.props.selectedItems) {
+            this.tool.onSelectionChanged(nextProps.selectedItems);
         }
 
         if (nextProps.isSelectModeActive && !this.props.isSelectModeActive) {
@@ -71,13 +75,15 @@ SelectMode.propTypes = {
     hoveredItemId: PropTypes.number,
     isSelectModeActive: PropTypes.bool.isRequired,
     onUpdateSvg: PropTypes.func.isRequired,
+    selectedItems: PropTypes.arrayOf(PropTypes.instanceOf(paper.Item)),
     setHoveredItem: PropTypes.func.isRequired,
     setSelectedItems: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
     isSelectModeActive: state.scratchPaint.mode === Modes.SELECT,
-    hoveredItemId: state.scratchPaint.hoveredItemId
+    hoveredItemId: state.scratchPaint.hoveredItemId,
+    selectedItems: state.scratchPaint.selectedItems
 });
 const mapDispatchToProps = dispatch => ({
     setHoveredItem: hoveredItemId => {

--- a/src/helper/group.js
+++ b/src/helper/group.js
@@ -6,6 +6,14 @@ const isGroup = function (item) {
     return isGroupItem(item);
 };
 
+/**
+ * Groups the given items. Other things are then deselected and the new group is selected.
+ * @param {!Array<paper.Item>} items Root level items to group
+ * @param {!function} clearSelectedItems Function to clear Redux state's selected items
+ * @param {!function} setSelectedItems Function to set Redux state with new list of selected items
+ * @param {!function} onUpdateSvg Function to let listeners know that SVG has changed.
+ * @return {paper.Group} the group if one is created, otherwise false.
+ */
 const groupItems = function (items, clearSelectedItems, setSelectedItems, onUpdateSvg) {
     if (items.length > 0) {
         const group = new paper.Group(items);
@@ -15,19 +23,26 @@ const groupItems = function (items, clearSelectedItems, setSelectedItems, onUpda
             group.children[i].selected = true;
         }
         setSelectedItems();
-        // @todo: Set selection bounds; enable/disable grouping icons
+        // @todo: enable/disable grouping icons
         onUpdateSvg();
         return group;
     }
     return false;
 };
 
+/**
+ * Groups the selected items. Other things are then deselected and the new group is selected.
+ * @param {!function} clearSelectedItems Function to clear Redux state's selected items
+ * @param {!function} setSelectedItems Function to set Redux state with new list of selected items
+ * @param {!function} onUpdateSvg Function to let listeners know that SVG has changed.
+ * @return {paper.Group} the group if one is created, otherwise false.
+ */
 const groupSelection = function (clearSelectedItems, setSelectedItems, onUpdateSvg) {
     const items = getSelectedRootItems();
     return groupItems(items, clearSelectedItems, setSelectedItems, onUpdateSvg);
 };
 
-const ungroupLoop = function (group, recursive, setSelectedItems) {
+const _ungroupLoop = function (group, recursive, setSelectedItems) {
     // Can't ungroup items that are not groups
     if (!group || !group.children || !isGroup(group)) return;
             
@@ -38,7 +53,7 @@ const ungroupLoop = function (group, recursive, setSelectedItems) {
         if (groupChild.hasChildren()) {
             // recursion (groups can contain groups, ie. from SVG import)
             if (recursive) {
-                ungroupLoop(groupChild, recursive, setSelectedItems);
+                _ungroupLoop(groupChild, recursive, setSelectedItems);
                 continue;
             }
             if (groupChild.children.length === 1) {
@@ -55,7 +70,16 @@ const ungroupLoop = function (group, recursive, setSelectedItems) {
     }
 };
 
-// ungroup items (only top hierarchy)
+/**
+ * Ungroups the given items. The new group is selected only if setSelectedItems is passed in.
+ * onUpdateSvg is called to notify listeners of a change on the SVG only if onUpdateSvg is passed in.
+ * The reason these arguments are optional on ungroupItems is because ungroupItems is used for parts of
+ * SVG import, which shouldn't change the selection or undo state.
+ *
+ * @param {!Array<paper.Item>} items Items to ungroup if they are groups
+ * @param {?function} setSelectedItems Function to set Redux state with new list of selected items
+ * @param {?function} onUpdateSvg Function to let listeners know that SVG has changed.
+ */
 const ungroupItems = function (items, setSelectedItems, onUpdateSvg) {
     if (items.length === 0) {
         return;
@@ -64,7 +88,7 @@ const ungroupItems = function (items, setSelectedItems, onUpdateSvg) {
     for (let i = 0; i < items.length; i++) {
         const item = items[i];
         if (isGroup(item) && !item.data.isPGTextItem) {
-            ungroupLoop(item, false /* recursive */, setSelectedItems);
+            _ungroupLoop(item, false /* recursive */, setSelectedItems);
 
             if (!item.hasChildren()) {
                 emptyGroups.push(item);
@@ -78,12 +102,19 @@ const ungroupItems = function (items, setSelectedItems, onUpdateSvg) {
     for (let j = 0; j < emptyGroups.length; j++) {
         emptyGroups[j].remove();
     }
-    // @todo: Set selection bounds; enable/disable grouping icons
+    // @todo: enable/disable grouping icons
     if (onUpdateSvg) {
         onUpdateSvg();
     }
 };
 
+/**
+ * Ungroups the selected items. Other items are deselected and the ungrouped items are selected.
+ *
+ * @param {!function} clearSelectedItems Function to clear Redux state's selected items
+ * @param {!function} setSelectedItems Function to set Redux state with new list of selected items
+ * @param {!function} onUpdateSvg Function to let listeners know that SVG has changed.
+ */
 const ungroupSelection = function (clearSelectedItems, setSelectedItems, onUpdateSvg) {
     const items = getSelectedRootItems();
     clearSelection(clearSelectedItems);

--- a/src/helper/selection-tools/bounding-box-tool.js
+++ b/src/helper/selection-tools/bounding-box-tool.js
@@ -50,6 +50,18 @@ class BoundingBoxTool {
     }
 
     /**
+     * Should be called if the selection changes to update the bounds of the bounding box.
+     * @param {Array<paper.Item>} selectedItems Array of selected items.
+     */
+    onSelectionChanged (selectedItems) {
+        if (selectedItems) {
+            this.setSelectionBounds();
+        } else {
+            this.removeBoundsPath();
+        }
+    }
+
+    /**
      * @param {!MouseEvent} event The mouse event
      * @param {boolean} clone Whether to clone on mouse down (e.g. alt key held)
      * @param {boolean} multiselect Whether to multiselect on mouse down (e.g. shift key held)

--- a/src/helper/selection-tools/select-tool.js
+++ b/src/helper/selection-tools/select-tool.js
@@ -58,6 +58,13 @@ class SelectTool extends paper.Tool {
         this.prevHoveredItemId = prevHoveredItemId;
     }
     /**
+     * Should be called if the selection changes to update the bounds of the bounding box.
+     * @param {Array<paper.Item>} selectedItems Array of selected items.
+     */
+    onSelectionChanged (selectedItems) {
+        this.boundingBoxTool.onSelectionChanged(selectedItems);
+    }
+    /**
      * Returns the hit options to use when conducting hit tests.
      * @param {boolean} preselectedOnly True if we should only return results that are already
      *     selected.

--- a/src/helper/tools/oval-tool.js
+++ b/src/helper/tools/oval-tool.js
@@ -47,6 +47,13 @@ class OvalTool extends paper.Tool {
             tolerance: OvalTool.TOLERANCE / paper.view.zoom
         };
     }
+    /**
+     * Should be called if the selection changes to update the bounds of the bounding box.
+     * @param {Array<paper.Item>} selectedItems Array of selected items.
+     */
+    onSelectionChanged (selectedItems) {
+        this.boundingBoxTool.onSelectionChanged(selectedItems);
+    }
     setColorState (colorState) {
         this.colorState = colorState;
     }

--- a/src/helper/tools/rect-tool.js
+++ b/src/helper/tools/rect-tool.js
@@ -47,6 +47,13 @@ class RectTool extends paper.Tool {
             tolerance: RectTool.TOLERANCE / paper.view.zoom
         };
     }
+    /**
+     * Should be called if the selection changes to update the bounds of the bounding box.
+     * @param {Array<paper.Item>} selectedItems Array of selected items.
+     */
+    onSelectionChanged (selectedItems) {
+        this.boundingBoxTool.onSelectionChanged(selectedItems);
+    }
     setColorState (colorState) {
         this.colorState = colorState;
     }

--- a/src/helper/undo.js
+++ b/src/helper/undo.js
@@ -11,19 +11,21 @@ const performSnapshot = function (dispatchPerformSnapshot) {
     // updateButtonVisibility();
 };
 
-const _restore = function (entry, onUpdateSvg) {
+const _restore = function (entry, setSelectedItems, onUpdateSvg) {
     for (const layer of paper.project.layers) {
         layer.removeChildren();
     }
     paper.project.clear();
     paper.project.importJSON(entry.json);
     paper.view.update();
+
+    setSelectedItems();
     onUpdateSvg(true /* skipSnapshot */);
 };
 
-const performUndo = function (undoState, dispatchPerformUndo, onUpdateSvg) {
+const performUndo = function (undoState, dispatchPerformUndo, setSelectedItems, onUpdateSvg) {
     if (undoState.pointer > 0) {
-        _restore(undoState.stack[undoState.pointer - 1], onUpdateSvg);
+        _restore(undoState.stack[undoState.pointer - 1], setSelectedItems, onUpdateSvg);
         dispatchPerformUndo();
 
         // @todo enable/disable buttons
@@ -32,9 +34,9 @@ const performUndo = function (undoState, dispatchPerformUndo, onUpdateSvg) {
 };
 
 
-const performRedo = function (undoState, dispatchPerformRedo, onUpdateSvg) {
+const performRedo = function (undoState, dispatchPerformRedo, setSelectedItems, onUpdateSvg) {
     if (undoState.pointer >= 0 && undoState.pointer < undoState.stack.length - 1) {
-        _restore(undoState.stack[undoState.pointer + 1], onUpdateSvg);
+        _restore(undoState.stack[undoState.pointer + 1], setSelectedItems, onUpdateSvg);
         dispatchPerformRedo();
         
         // @todo enable/disable buttons

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import PaintEditor from './containers/paint-editor.jsx';
-import SelectionHOV from './containers/selection-hoc.jsx';
+import SelectionHOC from './containers/selection-hoc.jsx';
 import ScratchPaintReducer from './reducers/scratch-paint-reducer';
 
-const Wrapped = SelectionHOV(PaintEditor);
+const Wrapped = SelectionHOC(PaintEditor);
 
 export {
     Wrapped as default,


### PR DESCRIPTION
Hook up group and ungroup buttons.

The bounding box tool needs to know when group/ungroup happen, so that it can redraw the selection bounds. It now listens to scratchPaint.selectedItems in the redux state and redraws the selection box when the selection changes. I had to pipe this state through multiple layers since bounding-box-tool is kind of far away from the components layer. I also added updates to the selection state in more places to keep it more accurate, for instance after reloading an old state via undo.