### PR TITLE
Fix GH-98: Remove user select state from form fields in paint

### DIFF
--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -3,6 +3,7 @@
 :local(.button) {
     background: none;
     cursor: pointer;
+    user-select: none;
 }
 :local(.button:active) {
     background-color: $motion-transparent; 

--- a/src/components/color-button/color-button.css
+++ b/src/components/color-button/color-button.css
@@ -7,6 +7,7 @@
 .color-button-swatch {
     position: relative;
     display: flex;
+    cursor: pointer;
     flex-basis: 2rem;
     flex-shrink: 0;
     height: 100%;
@@ -17,6 +18,8 @@
 
 .color-button-arrow {
     display: flex;
+    user-select: none;
+    cursor: pointer;
     flex-basis: 1rem;
     flex-shrink: 0;
     height: 100%;


### PR DESCRIPTION
Also add a pointer curser to the color-button html elements so that it’s clear those are clickable. This fixes #98.