### PR TITLE
Add basic zooming and panning

### DIFF
--- a/src/components/paint-editor/paint-editor.css
+++ b/src/components/paint-editor/paint-editor.css
@@ -19,7 +19,7 @@
 }
 
 .top-align-row {
-    display: flex; 
+    display: flex;
     padding-top: calc(5 * $grid-unit);
     flex-direction: row;
 }
@@ -29,7 +29,7 @@
 }
 
 .mod-dashed-border {
-    border-right: 1px dashed $ui-pane-border; 
+    border-right: 1px dashed $ui-pane-border;
     padding-right: calc(3 * $grid-unit);
 }
 
@@ -91,4 +91,9 @@ $border-radius: 0.25rem;
     align-items: flex-start;
     align-content: flex-start;
     justify-content: space-between;
+}
+
+.zoom-controls {
+    display: flex;
+    flex-direction: row-reverse;
 }

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -100,7 +100,7 @@ class PaintEditorComponent extends React.Component {
                                         onClick={this.props.onUndo}
                                     >
                                         <img
-                                            alt="Undo Icon"
+                                            alt="Undo"
                                             className={styles.buttonGroupButtonIcon}
                                             src={undoIcon}
                                         />
@@ -118,7 +118,7 @@ class PaintEditorComponent extends React.Component {
                                         onClick={this.props.onRedo}
                                     >
                                         <img
-                                            alt="Redo Icon"
+                                            alt="Redo"
                                             className={styles.buttonGroupButtonIcon}
                                             src={redoIcon}
                                         />
@@ -130,14 +130,14 @@ class PaintEditorComponent extends React.Component {
                             <InputGroup className={styles.modDashedBorder}>
                                 <LabeledIconButton
                                     disabled={!shouldShowGroup()}
-                                    imgAlt="Group Icon"
+                                    imgAlt="Group"
                                     imgSrc={groupIcon}
                                     title="Group"
                                     onClick={this.props.onGroup}
                                 />
                                 <LabeledIconButton
                                     disabled={!shouldShowUngroup()}
-                                    imgAlt="Ungroup Icon"
+                                    imgAlt="Ungroup"
                                     imgSrc={ungroupIcon}
                                     title="Ungroup"
                                     onClick={this.props.onUngroup}
@@ -148,14 +148,14 @@ class PaintEditorComponent extends React.Component {
                             <InputGroup className={styles.modDashedBorder}>
                                 <LabeledIconButton
                                     disabled={!shouldShowBringForward()}
-                                    imgAlt="Send Forward Icon"
+                                    imgAlt="Send Forward"
                                     imgSrc={sendForwardIcon}
                                     title="Forward"
                                     onClick={this.props.onSendForward}
                                 />
                                 <LabeledIconButton
                                     disabled={!shouldShowSendBackward()}
-                                    imgAlt="Send Backward Icon"
+                                    imgAlt="Send Backward"
                                     imgSrc={sendBackwardIcon}
                                     title="Backward"
                                     onClick={this.props.onSendBackward}
@@ -166,14 +166,14 @@ class PaintEditorComponent extends React.Component {
                             <InputGroup>
                                 <LabeledIconButton
                                     disabled={!shouldShowBringForward()}
-                                    imgAlt="Send to Front Icon"
+                                    imgAlt="Send to Front"
                                     imgSrc={sendFrontIcon}
                                     title="Front"
                                     onClick={this.props.onSendToFront}
                                 />
                                 <LabeledIconButton
                                     disabled={!shouldShowSendBackward()}
-                                    imgAlt="Send to Back Icon"
+                                    imgAlt="Send to Back"
                                     imgSrc={sendBackIcon}
                                     title="Back"
                                     onClick={this.props.onSendToBack}
@@ -183,7 +183,7 @@ class PaintEditorComponent extends React.Component {
                             {/* To be rotation point */}
                             {/* <InputGroup>
                                 <LabeledIconButton
-                                    imgAlt="Rotation Point Icon"
+                                    imgAlt="Rotation Point"
                                     imgSrc={rotationPointIcon}
                                     title="Rotation Point"
                                     onClick={function () {}}
@@ -264,7 +264,7 @@ class PaintEditorComponent extends React.Component {
                                     onClick={this.props.onZoomIn}
                                 >
                                     <img
-                                        alt="Zoom In Icon"
+                                        alt="Zoom In"
                                         className={styles.buttonGroupButtonIcon}
                                         src={zoomInIcon}
                                     />
@@ -274,7 +274,7 @@ class PaintEditorComponent extends React.Component {
                                     onClick={this.props.onZoomReset}
                                 >
                                     <img
-                                        alt="Zoom Reset Icon"
+                                        alt="Zoom Reset"
                                         className={styles.buttonGroupButtonIcon}
                                         src={zoomResetIcon}
                                     />
@@ -284,7 +284,7 @@ class PaintEditorComponent extends React.Component {
                                     onClick={this.props.onZoomOut}
                                 >
                                     <img
-                                        alt="Zoom Out Icon"
+                                        alt="Zoom Out"
                                         className={styles.buttonGroupButtonIcon}
                                         src={zoomOutIcon}
                                     />

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -39,6 +39,9 @@ import sendForwardIcon from './send-forward.svg';
 import sendFrontIcon from './send-front.svg';
 import undoIcon from './undo.svg';
 import ungroupIcon from './ungroup.svg';
+import zoomInIcon from './zoom-in.svg';
+import zoomOutIcon from './zoom-out.svg';
+import zoomResetIcon from './zoom-reset.svg';
 
 const BufferedInput = BufferedInputHOC(Input);
 const messages = defineMessages({
@@ -257,6 +260,41 @@ class PaintEditorComponent extends React.Component {
                             svgId={this.props.svgId}
                             onUpdateSvg={this.props.onUpdateSvg}
                         />
+                        {/* Zoom controls */}
+                        <InputGroup className={styles.zoomControls}>
+                            <ButtonGroup>
+                                <Button
+                                    className={styles.buttonGroupButton}
+                                    onClick={this.props.onZoomIn}
+                                >
+                                    <img
+                                        alt="Zoom In Icon"
+                                        className={styles.buttonGroupButtonIcon}
+                                        src={zoomInIcon}
+                                    />
+                                </Button>
+                                <Button
+                                    className={styles.buttonGroupButton}
+                                    onClick={this.props.onZoomReset}
+                                >
+                                    <img
+                                        alt="Zoom Reset Icon"
+                                        className={styles.buttonGroupButtonIcon}
+                                        src={zoomResetIcon}
+                                    />
+                                </Button>
+                                <Button
+                                    className={styles.buttonGroupButton}
+                                    onClick={this.props.onZoomOut}
+                                >
+                                    <img
+                                        alt="Zoom Out Icon"
+                                        className={styles.buttonGroupButtonIcon}
+                                        src={zoomOutIcon}
+                                    />
+                                </Button>
+                            </ButtonGroup>
+                        </InputGroup>
                     </div>
                 </div>
             </div>
@@ -279,6 +317,9 @@ PaintEditorComponent.propTypes = {
     onUngroup: PropTypes.func.isRequired,
     onUpdateName: PropTypes.func.isRequired,
     onUpdateSvg: PropTypes.func.isRequired,
+    onZoomIn: PropTypes.func.isRequired,
+    onZoomOut: PropTypes.func.isRequired,
+    onZoomReset: PropTypes.func.isRequired,
     rotationCenterX: PropTypes.number,
     rotationCenterY: PropTypes.number,
     svg: PropTypes.string,

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -225,20 +225,16 @@ class PaintEditorComponent extends React.Component {
                                 onUpdateSvg={this.props.onUpdateSvg}
                             />
                             <BrushMode
-                                canvas={this.state.canvas}
                                 onUpdateSvg={this.props.onUpdateSvg}
                             />
                             <EraserMode
-                                canvas={this.state.canvas}
                                 onUpdateSvg={this.props.onUpdateSvg}
                             />
                             <PenMode
-                                canvas={this.state.canvas}
                                 onUpdateSvg={this.props.onUpdateSvg}
                             />
                             {/* Text mode will go here */}
                             <LineMode
-                                canvas={this.state.canvas}
                                 onUpdateSvg={this.props.onUpdateSvg}
                             />
                             <OvalMode

--- a/src/components/paint-editor/zoom-in.svg
+++ b/src/components/paint-editor/zoom-in.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" viewBox="6 6 24 24">
+<defs>
+    <style>
+        .cls-4{fill:none;stroke:#575e75;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px;}
+    </style>
+</defs>
+<title>zoom-in</title>
+<g class="cls-3">
+    <circle class="cls-4" cx="18" cy="18" r="7"/>
+    <line class="cls-4" x1="23" y1="23" x2="26" y2="26"/>
+    <line class="cls-4" x1="16" y1="18" x2="20" y2="18"/>
+    <line class="cls-4" x1="18" y1="16" x2="18" y2="20"/>
+</g>
+</svg>

--- a/src/components/paint-editor/zoom-out.svg
+++ b/src/components/paint-editor/zoom-out.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" viewBox="6 6 24 24">
+<defs>
+    <style>
+        .cls-4{fill:none;stroke:#575e75;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px;}
+    </style>
+</defs>
+<title>zoom-out</title>
+<g class="cls-3">
+    <circle class="cls-4" cx="18" cy="18" r="7"/>
+    <line class="cls-4" x1="23" y1="23" x2="26" y2="26"/>
+    <line class="cls-4" x1="16" y1="18" x2="20" y2="18"/>
+</g>
+</svg>

--- a/src/components/paint-editor/zoom-reset.svg
+++ b/src/components/paint-editor/zoom-reset.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" viewBox="6 6 24 24">
+<defs>
+    <style>
+        .cls-4{fill:#575e75;}
+    </style>
+</defs>
+<title>zoom-reset</title>
+<g class="cls-3">
+    <rect class="cls-4" x="13" y="14" width="10" height="2" rx="1" ry="1"/>
+    <rect class="cls-4" x="13" y="20" width="10" height="2" rx="1" ry="1"/>
+</g>
+</svg>

--- a/src/containers/brush-mode.jsx
+++ b/src/containers/brush-mode.jsx
@@ -70,8 +70,6 @@ BrushMode.propTypes = {
     brushModeState: PropTypes.shape({
         brushSize: PropTypes.number.isRequired
     }),
-    canvas: PropTypes.instanceOf(Element).isRequired,
-    changeBrushSize: PropTypes.func.isRequired,
     clearSelectedItems: PropTypes.func.isRequired,
     colorState: PropTypes.shape({
         fillColor: PropTypes.string,

--- a/src/containers/brush-mode.jsx
+++ b/src/containers/brush-mode.jsx
@@ -17,8 +17,7 @@ class BrushMode extends React.Component {
         super(props);
         bindAll(this, [
             'activateTool',
-            'deactivateTool',
-            'onScroll'
+            'deactivateTool'
         ]);
         this.blob = new Blobbiness(
             this.props.onUpdateSvg, this.props.clearSelectedItems);
@@ -48,9 +47,6 @@ class BrushMode extends React.Component {
         // TODO: Instead of clearing selection, consider a kind of "draw inside"
         // analogous to how selection works with eraser
         clearSelection(this.props.clearSelectedItems);
-
-        // TODO: This is temporary until a component that provides the brush size is hooked up
-        this.props.canvas.addEventListener('mousewheel', this.onScroll);
         this.blob.activateTool({
             isEraser: false,
             ...this.props.colorState,
@@ -58,16 +54,7 @@ class BrushMode extends React.Component {
         });
     }
     deactivateTool () {
-        this.props.canvas.removeEventListener('mousewheel', this.onScroll);
         this.blob.deactivateTool();
-    }
-    onScroll (event) {
-        if (event.deltaY < 0) {
-            this.props.changeBrushSize(this.props.brushModeState.brushSize + 1);
-        } else if (event.deltaY > 0 && this.props.brushModeState.brushSize > 1) {
-            this.props.changeBrushSize(this.props.brushModeState.brushSize - 1);
-        }
-        return true;
     }
     render () {
         return (

--- a/src/containers/eraser-mode.jsx
+++ b/src/containers/eraser-mode.jsx
@@ -14,8 +14,7 @@ class EraserMode extends React.Component {
         super(props);
         bindAll(this, [
             'activateTool',
-            'deactivateTool',
-            'onScroll'
+            'deactivateTool'
         ]);
         this.blob = new Blobbiness(
             this.props.onUpdateSvg, this.props.clearSelectedItems);
@@ -41,21 +40,10 @@ class EraserMode extends React.Component {
         return nextProps.isEraserModeActive !== this.props.isEraserModeActive;
     }
     activateTool () {
-        this.props.canvas.addEventListener('mousewheel', this.onScroll);
-
         this.blob.activateTool({isEraser: true, ...this.props.eraserModeState});
     }
     deactivateTool () {
-        this.props.canvas.removeEventListener('mousewheel', this.onScroll);
         this.blob.deactivateTool();
-    }
-    onScroll (event) {
-        event.preventDefault();
-        if (event.deltaY < 0) {
-            this.props.changeBrushSize(this.props.eraserModeState.brushSize + 1);
-        } else if (event.deltaY > 0 && this.props.eraserModeState.brushSize > 1) {
-            this.props.changeBrushSize(this.props.eraserModeState.brushSize - 1);
-        }
     }
     render () {
         return (

--- a/src/containers/eraser-mode.jsx
+++ b/src/containers/eraser-mode.jsx
@@ -56,8 +56,6 @@ class EraserMode extends React.Component {
 }
 
 EraserMode.propTypes = {
-    canvas: PropTypes.instanceOf(Element).isRequired,
-    changeBrushSize: PropTypes.func.isRequired,
     clearSelectedItems: PropTypes.func.isRequired,
     eraserModeState: PropTypes.shape({
         brushSize: PropTypes.number.isRequired

--- a/src/containers/line-mode.jsx
+++ b/src/containers/line-mode.jsx
@@ -47,7 +47,7 @@ class LineMode extends React.Component {
     activateTool () {
         clearSelection(this.props.clearSelectedItems);
         this.tool = new paper.Tool();
-        
+
         this.path = null;
         this.hitResult = null;
 
@@ -182,14 +182,13 @@ class LineMode extends React.Component {
             removeHitPoint();
             this.hitResult = null;
         }
-        
+
         if (this.path) {
             this.props.onUpdateSvg();
             this.path = null;
         }
     }
     deactivateTool () {
-        this.props.canvas.removeEventListener('mousewheel', this.onScroll);
         this.tool.remove();
         this.tool = null;
         if (this.hitResult) {
@@ -211,7 +210,6 @@ class LineMode extends React.Component {
 }
 
 LineMode.propTypes = {
-    canvas: PropTypes.instanceOf(Element).isRequired,
     clearSelectedItems: PropTypes.func.isRequired,
     colorState: PropTypes.shape({
         fillColor: PropTypes.string,

--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -11,6 +11,7 @@ import {performUndo, performRedo, performSnapshot, shouldShowUndo, shouldShowRed
 import {bringToFront, sendBackward, sendToBack, bringForward} from '../helper/order';
 import {groupSelection, ungroupSelection} from '../helper/group';
 import {getSelectedLeafItems} from '../helper/selection';
+import {resetZoom, zoomOnSelection} from '../helper/view';
 
 import Modes from '../modes/modes';
 import {connect} from 'react-redux';
@@ -91,6 +92,15 @@ class PaintEditor extends React.Component {
     canRedo () {
         return shouldShowRedo(this.props.undoState);
     }
+    handleZoomIn () {
+        zoomOnSelection(0.25);
+    }
+    handleZoomOut () {
+        zoomOnSelection(-0.25);
+    }
+    handleZoomReset () {
+        resetZoom();
+    }
     render () {
         return (
             <PaintEditorComponent
@@ -111,6 +121,9 @@ class PaintEditor extends React.Component {
                 onUngroup={this.handleUngroup}
                 onUpdateName={this.props.onUpdateName}
                 onUpdateSvg={this.handleUpdateSvg}
+                onZoomIn={this.handleZoomIn}
+                onZoomOut={this.handleZoomOut}
+                onZoomReset={this.handleZoomReset}
             />
         );
     }

--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -42,6 +42,11 @@ class PaintEditor extends React.Component {
         document.removeEventListener('keydown', this.props.onKeyPress);
     }
     handleUpdateSvg (skipSnapshot) {
+        // Store the zoom/pan and restore it after snapshotting
+        // TODO Only doing this because snapshotting at zoom/pan makes export wrong
+        const oldZoom = paper.project.view.zoom;
+        const oldCenter = paper.project.view.center.clone();
+        resetZoom();
         // Hide guide layer
         const guideLayer = getGuideLayer();
         const backgroundGuideLayer = getBackgroundGuideLayer();
@@ -61,6 +66,10 @@ class PaintEditor extends React.Component {
         paper.project.addLayer(backgroundGuideLayer);
         backgroundGuideLayer.sendToBack();
         paper.project.addLayer(guideLayer);
+        // Restore old zoom
+        paper.project.view.zoom = oldZoom;
+        paper.project.view.center = oldCenter;
+        paper.project.view.update();
     }
     handleUndo () {
         performUndo(this.props.undoState, this.props.onUndo, this.props.setSelectedItems, this.handleUpdateSvg);

--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -19,6 +19,9 @@ import bindAll from 'lodash.bindall';
 import paper from '@scratch/paper';
 
 class PaintEditor extends React.Component {
+    static get ZOOM_INCREMENT () {
+        return 0.5;
+    }
     constructor (props) {
         super(props);
         bindAll(this, [
@@ -102,10 +105,10 @@ class PaintEditor extends React.Component {
         return shouldShowRedo(this.props.undoState);
     }
     handleZoomIn () {
-        zoomOnSelection(0.25);
+        zoomOnSelection(PaintEditor.ZOOM_INCREMENT);
     }
     handleZoomOut () {
-        zoomOnSelection(-0.25);
+        zoomOnSelection(-PaintEditor.ZOOM_INCREMENT);
     }
     handleZoomReset () {
         resetZoom();

--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -10,7 +10,7 @@ import {undoSnapshot, clearUndoState} from '../reducers/undo';
 import {isGroup, ungroupItems} from '../helper/group';
 import {setupLayers} from '../helper/layer';
 import {deleteSelection, getSelectedLeafItems} from '../helper/selection';
-import {pan, zoomOnFixedPoint} from '../helper/view';
+import {pan, resetZoom, zoomOnFixedPoint} from '../helper/view';
 
 import {setSelectedItems} from '../reducers/selected-items';
 
@@ -48,7 +48,14 @@ class PaperCanvas extends React.Component {
         }
         this.props.clearUndo();
         if (newProps.svg) {
+            // Store the zoom/pan and restore it after importing a new SVG
+            const oldZoom = paper.project.view.zoom;
+            const oldCenter = paper.project.view.center.clone();
+            resetZoom();
             this.importSvg(newProps.svg, newProps.rotationCenterX, newProps.rotationCenterY);
+            paper.project.view.zoom = oldZoom;
+            paper.project.view.center = oldCenter;
+            paper.project.view.update();
         }
     }
     componentWillUnmount () {

--- a/src/helper/view.js
+++ b/src/helper/view.js
@@ -1,0 +1,70 @@
+import paper from '@scratch/paper';
+import {getSelectedRootItems} from './selection';
+
+// Zoom keeping the selection center (if any) fixed.
+const zoomOnSelection = (deltaZoom) => {
+    let fixedPoint;
+    const items = getSelectedRootItems();
+    if (items.length > 0) {
+        let rect = null;
+        for (const item of items) {
+            if (rect) {
+                rect = rect.unite(item.bounds);
+            } else {
+                rect = item.bounds;
+            }
+        }
+        fixedPoint = rect.center;
+    } else {
+        fixedPoint = paper.project.view.center;
+    }
+    zoomOnFixedPoint(deltaZoom, fixedPoint);
+};
+
+// Zoom keeping a project-space point fixed.
+// This article was helpful http://matthiasberth.com/tech/stable-zoom-and-pan-in-paperjs
+const zoomOnFixedPoint = (deltaZoom, fixedPoint) => {
+    const {view} = paper.project;
+    const preZoomCenter = view.center;
+    const newZoom = Math.max(1, view.zoom + deltaZoom);
+    const scaling = view.zoom / newZoom;
+    const preZoomOffset = fixedPoint.subtract(preZoomCenter);
+    const postZoomOffset = fixedPoint.subtract(preZoomOffset.multiply(scaling))
+        .subtract(preZoomCenter);
+    view.zoom = newZoom;
+    view.translate(postZoomOffset.multiply(-1));
+    clampViewBounds();
+};
+
+const resetZoom = () => {
+    paper.project.view.zoom = 1;
+    clampViewBounds();
+};
+
+const pan = (dx, dy) => {
+    paper.project.view.scrollBy(new paper.Point(dx, dy));
+    clampViewBounds();
+};
+
+const clampViewBounds = () => {
+    const {left, right, top, bottom} = paper.project.view.bounds;
+    if (left < 0) {
+        paper.project.view.scrollBy(new paper.Point(-left, 0));
+    }
+    if (top < 0) {
+        paper.project.view.scrollBy(new paper.Point(0, -top));
+    }
+    if (bottom > 400) {
+        paper.project.view.scrollBy(new paper.Point(0, 400 - bottom));
+    }
+    if (right > 500) {
+        paper.project.view.scrollBy(new paper.Point(500 - right, 0));
+    }
+};
+
+export {
+    pan,
+    resetZoom,
+    zoomOnSelection,
+    zoomOnFixedPoint
+}

--- a/src/helper/view.js
+++ b/src/helper/view.js
@@ -1,8 +1,24 @@
 import paper from '@scratch/paper';
 import {getSelectedRootItems} from './selection';
 
+const clampViewBounds = () => {
+    const {left, right, top, bottom} = paper.project.view.bounds;
+    if (left < 0) {
+        paper.project.view.scrollBy(new paper.Point(-left, 0));
+    }
+    if (top < 0) {
+        paper.project.view.scrollBy(new paper.Point(0, -top));
+    }
+    if (bottom > 400) {
+        paper.project.view.scrollBy(new paper.Point(0, 400 - bottom));
+    }
+    if (right > 500) {
+        paper.project.view.scrollBy(new paper.Point(500 - right, 0));
+    }
+};
+
 // Zoom keeping the selection center (if any) fixed.
-const zoomOnSelection = (deltaZoom) => {
+const zoomOnSelection = deltaZoom => {
     let fixedPoint;
     const items = getSelectedRootItems();
     if (items.length > 0) {
@@ -46,25 +62,9 @@ const pan = (dx, dy) => {
     clampViewBounds();
 };
 
-const clampViewBounds = () => {
-    const {left, right, top, bottom} = paper.project.view.bounds;
-    if (left < 0) {
-        paper.project.view.scrollBy(new paper.Point(-left, 0));
-    }
-    if (top < 0) {
-        paper.project.view.scrollBy(new paper.Point(0, -top));
-    }
-    if (bottom > 400) {
-        paper.project.view.scrollBy(new paper.Point(0, 400 - bottom));
-    }
-    if (right > 500) {
-        paper.project.view.scrollBy(new paper.Point(500 - right, 0));
-    }
-};
-
 export {
     pan,
     resetZoom,
     zoomOnSelection,
     zoomOnFixedPoint
-}
+};

--- a/src/helper/view.js
+++ b/src/helper/view.js
@@ -17,6 +17,21 @@ const clampViewBounds = () => {
     }
 };
 
+// Zoom keeping a project-space point fixed.
+// This article was helpful http://matthiasberth.com/tech/stable-zoom-and-pan-in-paperjs
+const zoomOnFixedPoint = (deltaZoom, fixedPoint) => {
+    const {view} = paper.project;
+    const preZoomCenter = view.center;
+    const newZoom = Math.max(1, view.zoom + deltaZoom);
+    const scaling = view.zoom / newZoom;
+    const preZoomOffset = fixedPoint.subtract(preZoomCenter);
+    const postZoomOffset = fixedPoint.subtract(preZoomOffset.multiply(scaling))
+        .subtract(preZoomCenter);
+    view.zoom = newZoom;
+    view.translate(postZoomOffset.multiply(-1));
+    clampViewBounds();
+};
+
 // Zoom keeping the selection center (if any) fixed.
 const zoomOnSelection = deltaZoom => {
     let fixedPoint;
@@ -35,21 +50,6 @@ const zoomOnSelection = deltaZoom => {
         fixedPoint = paper.project.view.center;
     }
     zoomOnFixedPoint(deltaZoom, fixedPoint);
-};
-
-// Zoom keeping a project-space point fixed.
-// This article was helpful http://matthiasberth.com/tech/stable-zoom-and-pan-in-paperjs
-const zoomOnFixedPoint = (deltaZoom, fixedPoint) => {
-    const {view} = paper.project;
-    const preZoomCenter = view.center;
-    const newZoom = Math.max(1, view.zoom + deltaZoom);
-    const scaling = view.zoom / newZoom;
-    const preZoomOffset = fixedPoint.subtract(preZoomCenter);
-    const postZoomOffset = fixedPoint.subtract(preZoomOffset.multiply(scaling))
-        .subtract(preZoomCenter);
-    view.zoom = newZoom;
-    view.translate(postZoomOffset.multiply(-1));
-    clampViewBounds();
 };
 
 const resetZoom = () => {


### PR DESCRIPTION
This PR adds some basic zoom in/out/reset buttons as well as basic panning functionality from the scroll wheel. Basically, zoom/pan is easy, but making scrollbars is hard. 

1. Zoom in, zoom out and reset buttons. Zoom by default tracks the selection, or zooms to the current view center.
2. Wheel zoom (holding ctrl/cmd while scrolling) which zooms to the point your mouse is over.
3. Panning, which for trackpads that do deltaX/Y just follows trackpad movement, for mousewheel it does up/down by default and left/right when you hold <kbd>Shift</kbd>. This particular key combination is actually because it is the default way the browser translates deltaX/deltaY when using a mouse. 

![zoom-pan](https://user-images.githubusercontent.com/654102/32105774-9b6ed386-baf7-11e7-88ac-5ede2855fc9e.gif)

My feeling with this is that it obviously isn't good enough to use with kids (because of the lack of scrollbars/discoverability) but it might be very helpful to have in order to make the internal workshop better by allowing people to make more things. 
