### PR TITLE
Only show outline box if not mixed colors

### DIFF
--- a/src/components/color-button/color-button.jsx
+++ b/src/components/color-button/color-button.jsx
@@ -20,7 +20,7 @@ const ColorButtonComponent = props => (
     >
         <div
             className={classNames(styles.colorButtonSwatch, {
-                [styles.outlineSwatch]: props.outline
+                [styles.outlineSwatch]: props.outline && !(props.color === MIXED)
             })}
             style={{
                 background: colorToBackground(props.color)


### PR DESCRIPTION
Showing both the outline box and the mixed colors icon looks bad. Only show the outline box if it isn't mixed colors. 

Broken
![image](https://user-images.githubusercontent.com/654102/32147024-6ecea57a-bcb6-11e7-8302-6d2fe6a7bd47.png)

Fixed
![image](https://user-images.githubusercontent.com/654102/32147023-699cfdc2-bcb6-11e7-94f3-b8159716d2e7.png)