### PR TITLE
Make color sliders go from 0 to 100

### DIFF
--- a/src/components/forms/slider.jsx
+++ b/src/components/forms/slider.jsx
@@ -32,7 +32,7 @@ class SliderComponent extends React.Component {
         event.preventDefault();
         const backgroundBBox = this.background.getBoundingClientRect();
         const x = event.clientX - backgroundBBox.left;
-        this.props.onChange(Math.max(1, Math.min(99, 100 * x / backgroundBBox.width)));
+        this.props.onChange(Math.max(0, Math.min(100, 100 * x / backgroundBBox.width)));
     }
 
     setBackground (ref) {


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/141

![fix-slider-ranges](https://user-images.githubusercontent.com/654102/32147156-ac5a7110-bcb8-11e7-9d54-5d3559be275e.gif)

This was accidentally left in from a time when I was doing color math differently. Works now!