### PR TITLE
Fix GH-131: Add a larger width on small inputs

### DIFF
--- a/src/components/forms/input.css
+++ b/src/components/forms/input.css
@@ -41,6 +41,6 @@ See https://github.com/LLK/scratch-paint/issues/13 */
 }
 
 .input-small {
-    width: 3rem; 
+    width: 3.5rem; 
     text-align: center;
 }


### PR DESCRIPTION
Fixes #131 – I ended up deciding to do this for all inputs because the original `3rem` makes it cut off text past 1 char for any input that is only `3rem`, so `3.5rem` seemed like an okay width for this component.