### PR TITLE
Fix GH-122: change size inputs to input with custon onChange

### DIFF
--- a/src/components/forms/buffered-input-hoc.jsx
+++ b/src/components/forms/buffered-input-hoc.jsx
@@ -2,10 +2,6 @@
 @todo This file is copied from GUI and should be pulled out into a shared library.
 See https://github.com/LLK/scratch-paint/issues/13 */
 
-/* ACTUALLY, THIS HAS BEEN EDITED ;)
-handleChange() was adjusted here to actually send a change to `onSubmit()` so that
-brush/eraser sizes change immediately on a numeric input*/
-
 import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -43,11 +39,6 @@ export default function (Input) {
             this.setState({value: null});
         }
         handleChange (e) {
-            const isNumeric = typeof this.props.value === 'number';
-            const validatesNumeric = isNumeric ? !isNaN(e.target.value) : true;
-            if (e.target.value !== null && validatesNumeric) {
-                this.props.onSubmit(isNumeric ? Number(e.target.value) : e.target.value);
-            }
             this.setState({value: e.target.value});
         }
         render () {

--- a/src/components/forms/live-input-hoc.jsx
+++ b/src/components/forms/live-input-hoc.jsx
@@ -1,0 +1,60 @@
+import bindAll from 'lodash.bindall';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Higher Order Component to manage inputs that submit on change and <enter>
+ * @param {React.Component} Input text input that consumes onChange, onBlur, onKeyPress
+ * @returns {React.Component} Live input that calls onSubmit on change and <enter>
+ */
+export default function (Input) {
+    class LiveInput extends React.Component {
+        constructor (props) {
+            super(props);
+            bindAll(this, [
+                'handleChange',
+                'handleKeyPress',
+                'handleFlush'
+            ]);
+            this.state = {
+                value: null
+            };
+        }
+        handleKeyPress (e) {
+            if (e.key === 'Enter') {
+                this.handleChange(e);
+                e.target.blur();
+            }
+        }
+        handleFlush () {
+            this.setState({value: null});
+        }
+        handleChange (e) {
+            const isNumeric = typeof this.props.value === 'number';
+            const validatesNumeric = isNumeric ? !isNaN(e.target.value) : true;
+            if (e.target.value !== null && validatesNumeric) {
+                this.props.onSubmit(Number(e.target.value));
+            }
+            this.setState({value: e.target.value});
+        }
+        render () {
+            const liveValue = this.state.value === null ? this.props.value : this.state.value;
+            return (
+                <Input
+                    {...this.props}
+                    value={liveValue}
+                    onBlur={this.handleFlush}
+                    onChange={this.handleChange}
+                    onKeyPress={this.handleKeyPress}
+                />
+            );
+        }
+    }
+
+    LiveInput.propTypes = {
+        onSubmit: PropTypes.func.isRequired,
+        value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    };
+
+    return LiveInput;
+}

--- a/src/components/forms/live-input-hoc.jsx
+++ b/src/components/forms/live-input-hoc.jsx
@@ -32,8 +32,12 @@ export default function (Input) {
         handleChange (e) {
             const isNumeric = typeof this.props.value === 'number';
             const validatesNumeric = isNumeric ? !isNaN(e.target.value) : true;
-            if (e.target.value !== null && validatesNumeric) {
-                this.props.onSubmit(Number(e.target.value));
+            if (e.target.value !== null && validatesNumeric ) {
+                let val = Number(e.target.value);
+                if (typeof this.props.max !== 'undefined' && val > this.props.max) {
+                    val = this.props.max;
+                }
+                this.props.onSubmit(val);
             }
             this.setState({value: e.target.value});
         }
@@ -52,6 +56,7 @@ export default function (Input) {
     }
 
     LiveInput.propTypes = {
+        max: PropTypes.number,
         onSubmit: PropTypes.func.isRequired,
         value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     };

--- a/src/components/forms/live-input-hoc.jsx
+++ b/src/components/forms/live-input-hoc.jsx
@@ -34,8 +34,11 @@ export default function (Input) {
             const validatesNumeric = isNumeric ? !isNaN(e.target.value) : true;
             if (e.target.value !== null && validatesNumeric ) {
                 let val = Number(e.target.value);
-                if (typeof this.props.max !== 'undefined' && val > this.props.max) {
+                if (typeof this.props.max !== 'undefined' && val > Number(this.props.max)) {
                     val = this.props.max;
+                }
+                if (typeof this.props.min !== 'undefined' && val < Number(this.props.min)) {
+                    val = this.props.min;
                 }
                 this.props.onSubmit(val);
             }
@@ -57,6 +60,7 @@ export default function (Input) {
 
     LiveInput.propTypes = {
         max: PropTypes.number,
+        min: PropTypes.number,
         onSubmit: PropTypes.func.isRequired,
         value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     };

--- a/src/components/mode-tools/mode-tools.jsx
+++ b/src/components/mode-tools/mode-tools.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {changeBrushSize} from '../../reducers/brush-mode';
 import {changeBrushSize as changeEraserSize} from '../../reducers/eraser-mode';
 
+import LiveInputHOC from '../forms/live-input-hoc.jsx';
 import {injectIntl, intlShape} from 'react-intl';
 import Input from '../forms/input.jsx';
 // import LabeledIconButton from '../labeled-icon-button/labeled-icon-button.jsx';
@@ -21,6 +22,7 @@ import eraserIcon from '../eraser-mode/eraser.svg';
 
 import {MAX_STROKE_WIDTH} from '../../reducers/stroke-width';
 
+const LiveInput = LiveInputHOC(Input);
 const ModeToolsComponent = props => {
     const brushMessage = props.intl.formatMessage({
         defaultMessage: 'Brush',
@@ -44,17 +46,12 @@ const ModeToolsComponent = props => {
                         src={brushIcon}
                     />
                 </div>
-                <Input
+                <LiveInput
                     small
                     max={MAX_STROKE_WIDTH}
                     min="1"
                     type="number"
                     value={props.brushValue}
-                    onChange={function (e) {
-                        if (e.target.value !== null && !isNaN(e.target.value)) {
-                            props.onBrushSliderChange(Number(e.target.value));
-                        }
-                    }}
                     onSubmit={props.onBrushSliderChange}
                 />
             </div>
@@ -69,17 +66,12 @@ const ModeToolsComponent = props => {
                         src={eraserIcon}
                     />
                 </div>
-                <Input
+                <LiveInput
                     small
                     max={MAX_STROKE_WIDTH}
                     min="1"
                     type="number"
                     value={props.eraserValue}
-                    onChange={function (e) {
-                        if (e.target.value !== null && !isNaN(e.target.value)) {
-                            props.onEraserSliderChange(Number(e.target.value));
-                        }
-                    }}
                     onSubmit={props.onEraserSliderChange}
                 />
             </div>

--- a/src/components/mode-tools/mode-tools.jsx
+++ b/src/components/mode-tools/mode-tools.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import {changeBrushSize} from '../../reducers/brush-mode';
 import {changeBrushSize as changeEraserSize} from '../../reducers/eraser-mode';
 
-import BufferedInputHOC from '../forms/buffered-input-hoc.jsx';
 import {injectIntl, intlShape} from 'react-intl';
 import Input from '../forms/input.jsx';
 // import LabeledIconButton from '../labeled-icon-button/labeled-icon-button.jsx';
@@ -22,7 +21,6 @@ import eraserIcon from '../eraser-mode/eraser.svg';
 
 import {MAX_STROKE_WIDTH} from '../../reducers/stroke-width';
 
-const BufferedInput = BufferedInputHOC(Input);
 const ModeToolsComponent = props => {
     const brushMessage = props.intl.formatMessage({
         defaultMessage: 'Brush',
@@ -46,12 +44,17 @@ const ModeToolsComponent = props => {
                         src={brushIcon}
                     />
                 </div>
-                <BufferedInput
+                <Input
                     small
                     max={MAX_STROKE_WIDTH}
                     min="1"
                     type="number"
                     value={props.brushValue}
+                    onChange={function (e) {
+                        if (e.target.value !== null && !isNaN(e.target.value)) {
+                            props.onBrushSliderChange(Number(e.target.value));
+                        }
+                    }}
                     onSubmit={props.onBrushSliderChange}
                 />
             </div>
@@ -66,12 +69,17 @@ const ModeToolsComponent = props => {
                         src={eraserIcon}
                     />
                 </div>
-                <BufferedInput
+                <Input
                     small
                     max={MAX_STROKE_WIDTH}
                     min="1"
                     type="number"
                     value={props.eraserValue}
+                    onChange={function (e) {
+                        if (e.target.value !== null && !isNaN(e.target.value)) {
+                            props.onEraserSliderChange(Number(e.target.value));
+                        }
+                    }}
                     onSubmit={props.onEraserSliderChange}
                 />
             </div>

--- a/src/components/stroke-width-indicator.jsx
+++ b/src/components/stroke-width-indicator.jsx
@@ -1,22 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import BufferedInputHOC from './forms/buffered-input-hoc.jsx';
 import Input from './forms/input.jsx';
 import InputGroup from './input-group/input-group.jsx';
 
 import {MAX_STROKE_WIDTH} from '../reducers/stroke-width';
 
-const BufferedInput = BufferedInputHOC(Input);
 const StrokeWidthIndicatorComponent = props => (
     <InputGroup disabled={props.disabled}>
-        <BufferedInput
+        <Input
             small
             disabled={props.disabled}
             max={MAX_STROKE_WIDTH}
             min="0"
             type="number"
             value={props.strokeWidth ? props.strokeWidth : 0}
+            onChange={function (e) {
+                if (e.target.value !== null && !isNaN(e.target.value)) {
+                    props.onChangeStrokeWidth(Number(e.target.value));
+                }
+
+            }}
             onSubmit={props.onChangeStrokeWidth}
         />
     </InputGroup>

--- a/src/components/stroke-width-indicator.jsx
+++ b/src/components/stroke-width-indicator.jsx
@@ -3,24 +3,20 @@ import PropTypes from 'prop-types';
 
 import Input from './forms/input.jsx';
 import InputGroup from './input-group/input-group.jsx';
+import LiveInputHOC from './forms/live-input-hoc.jsx';
 
 import {MAX_STROKE_WIDTH} from '../reducers/stroke-width';
 
+const LiveInput = LiveInputHOC(Input);
 const StrokeWidthIndicatorComponent = props => (
     <InputGroup disabled={props.disabled}>
-        <Input
+        <LiveInput
             small
             disabled={props.disabled}
             max={MAX_STROKE_WIDTH}
             min="0"
             type="number"
             value={props.strokeWidth ? props.strokeWidth : 0}
-            onChange={function (e) {
-                if (e.target.value !== null && !isNaN(e.target.value)) {
-                    props.onChangeStrokeWidth(Number(e.target.value));
-                }
-
-            }}
             onSubmit={props.onChangeStrokeWidth}
         />
     </InputGroup>


### PR DESCRIPTION
This fixes #122 by reverting the changes to `bufferedInputHOC`, and adding a custom `onChange` handler to the mode tools for brush and eraser, and making them `Input` components. Same goes for the strok width indicator.