### PR TITLE
Try to make layer management more robust

### DIFF
--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -7,7 +7,7 @@ import {undo, redo, undoSnapshot} from '../reducers/undo';
 import {clearSelectedItems, setSelectedItems} from '../reducers/selected-items';
 import {incrementPasteOffset, setClipboardItems} from '../reducers/clipboard';
 
-import {getGuideLayer, getBackgroundGuideLayer} from '../helper/layer';
+import {hideGuideLayers, showGuideLayers} from '../helper/layer';
 import {performUndo, performRedo, performSnapshot, shouldShowUndo, shouldShowRedo} from '../helper/undo';
 import {bringToFront, sendBackward, sendToBack, bringForward} from '../helper/order';
 import {groupSelection, ungroupSelection} from '../helper/group';
@@ -53,11 +53,9 @@ class PaintEditor extends React.Component {
         const oldZoom = paper.project.view.zoom;
         const oldCenter = paper.project.view.center.clone();
         resetZoom();
-        // Hide guide layer
-        const guideLayer = getGuideLayer();
-        const backgroundGuideLayer = getBackgroundGuideLayer();
-        guideLayer.remove();
-        backgroundGuideLayer.remove();
+
+        const guideLayers = hideGuideLayers();
+
         const bounds = paper.project.activeLayer.bounds;
         this.props.onUpdateSvg(
             paper.project.exportSVG({
@@ -66,12 +64,13 @@ class PaintEditor extends React.Component {
             }),
             paper.project.view.center.x - bounds.x,
             paper.project.view.center.y - bounds.y);
+
+        showGuideLayers(guideLayers);
+
         if (!skipSnapshot) {
             performSnapshot(this.props.undoSnapshot);
         }
-        paper.project.addLayer(backgroundGuideLayer);
-        backgroundGuideLayer.sendToBack();
-        paper.project.addLayer(guideLayer);
+
         // Restore old zoom
         paper.project.view.zoom = oldZoom;
         paper.project.view.center = oldCenter;

--- a/src/helper/undo.js
+++ b/src/helper/undo.js
@@ -1,23 +1,14 @@
 // undo functionality
 // modifed from https://github.com/memononen/stylii
 import paper from '@scratch/paper';
-import {getBackgroundGuideLayer} from '../helper/layer';
+import {hideGuideLayers, showGuideLayers} from '../helper/layer';
 
 const performSnapshot = function (dispatchPerformSnapshot) {
-    const backgroundGuideLayer = getBackgroundGuideLayer();
-    if (backgroundGuideLayer) {
-        backgroundGuideLayer.remove();
-    }
+    const guideLayers = hideGuideLayers();
     dispatchPerformSnapshot({
         json: paper.project.exportJSON({asString: false})
     });
-    if (backgroundGuideLayer) {
-        paper.project.addLayer(backgroundGuideLayer);
-        backgroundGuideLayer.sendToBack();
-    }
-
-    // @todo enable/disable buttons
-    // updateButtonVisibility();
+    showGuideLayers(guideLayers);
 };
 
 const _restore = function (entry, setSelectedItems, onUpdateSvg) {
@@ -38,9 +29,6 @@ const performUndo = function (undoState, dispatchPerformUndo, setSelectedItems, 
     if (undoState.pointer > 0) {
         _restore(undoState.stack[undoState.pointer - 1], setSelectedItems, onUpdateSvg);
         dispatchPerformUndo();
-
-        // @todo enable/disable buttons
-        // updateButtonVisibility();
     }
 };
 
@@ -49,9 +37,6 @@ const performRedo = function (undoState, dispatchPerformRedo, setSelectedItems, 
     if (undoState.pointer >= 0 && undoState.pointer < undoState.stack.length - 1) {
         _restore(undoState.stack[undoState.pointer + 1], setSelectedItems, onUpdateSvg);
         dispatchPerformRedo();
-        
-        // @todo enable/disable buttons
-        // updateButtonVisibility();
     }
 };
 


### PR DESCRIPTION
I still don't have a good repro for https://github.com/LLK/scratch-paint/issues/172, but I was able to repro it with ~5 min of random bashing ~5 times before this fix, and haven't seen the issue yet after this fix. I've added logging so that if anyone sees the error again we will have a way to find out.

This generally tries to make layers more robust. Instead of making the guide layer on-demand, make all layers only once when the component is created. Thereafter the layers can be temporarily removed, but new ones can't be created.

What this is trying to fix:
After switching costumes, we could somehow end up with multiple guide layers, and a guide layer would get set to be the active layer. This means all new drawing operations would be added to the guide layer. Since drawings were on the wrong layer, only some of the drawing would be exported to the stage, and they would export with the wrong center point. Undo/redo state would be irrecoverably broken (things would keep getting duplicated)