### PR TITLE
Clean up selection state

### DIFF
--- a/src/helper/selection-tools/bounding-box-tool.js
+++ b/src/helper/selection-tools/bounding-box-tool.js
@@ -121,7 +121,6 @@ class BoundingBoxTool {
         this._modeMap[this.mode].onMouseUp(event);
 
         this.mode = null;
-        this.setSelectionBounds();
     }
     setSelectionBounds () {
         this.removeBoundsPath();

--- a/src/helper/selection-tools/select-tool.js
+++ b/src/helper/selection-tools/select-tool.js
@@ -45,7 +45,6 @@ class SelectTool extends paper.Tool {
 
         selectRootItem();
         setSelectedItems();
-        this.boundingBoxTool.setSelectionBounds();
     }
     /**
      * To be called when the hovered item changes. When the select tool hovers over a
@@ -125,7 +124,6 @@ class SelectTool extends paper.Tool {
 
         if (this.selectionBoxMode) {
             this.selectionBoxTool.onMouseUp(event);
-            this.boundingBoxTool.setSelectionBounds();
         } else {
             this.boundingBoxTool.onMouseUp(event);
         }

--- a/src/helper/tools/oval-tool.js
+++ b/src/helper/tools/oval-tool.js
@@ -18,6 +18,7 @@ class OvalTool extends paper.Tool {
      */
     constructor (setSelectedItems, clearSelectedItems, onUpdateSvg) {
         super();
+        this.setSelectedItems = setSelectedItems;
         this.clearSelectedItems = clearSelectedItems;
         this.onUpdateSvg = onUpdateSvg;
         this.prevHoveredItemId = null;
@@ -116,7 +117,7 @@ class OvalTool extends paper.Tool {
                 this.oval = null;
 
                 ovalPath.selected = true;
-                this.boundingBoxTool.setSelectionBounds();
+                this.setSelectedItems();
                 this.onUpdateSvg();
             }
         }

--- a/src/helper/tools/rect-tool.js
+++ b/src/helper/tools/rect-tool.js
@@ -18,6 +18,7 @@ class RectTool extends paper.Tool {
      */
     constructor (setSelectedItems, clearSelectedItems, onUpdateSvg) {
         super();
+        this.setSelectedItems = setSelectedItems;
         this.clearSelectedItems = clearSelectedItems;
         this.onUpdateSvg = onUpdateSvg;
         this.prevHoveredItemId = null;
@@ -108,7 +109,7 @@ class RectTool extends paper.Tool {
                 this.rect = null;
             } else {
                 this.rect.selected = true;
-                this.boundingBoxTool.setSelectionBounds();
+                this.setSelectedItems();
                 this.onUpdateSvg();
                 this.rect = null;
             }


### PR DESCRIPTION
The bounding box tool now listens on the selected items in the redux state, so there's no need to call boundingBoxTool.setSelectionBounds directly. It will be called automatically sometime after setSelectedItems is called.

This also fixes https://github.com/LLK/scratch-paint/issues/181 by calling setSelectedItems in a couple of places where it was missing before.