### PR TITLE
Widen stroke width indicator

### DIFF
--- a/src/components/stroke-width-indicator.css
+++ b/src/components/stroke-width-indicator.css
@@ -1,0 +1,3 @@
+#stroke-width-indicator {
+    width: 4rem;
+}

--- a/src/components/stroke-width-indicator.jsx
+++ b/src/components/stroke-width-indicator.jsx
@@ -7,12 +7,15 @@ import LiveInputHOC from './forms/live-input-hoc.jsx';
 
 import {MAX_STROKE_WIDTH} from '../reducers/stroke-width';
 
+import styles from './stroke-width-indicator.css';
+
 const LiveInput = LiveInputHOC(Input);
 const StrokeWidthIndicatorComponent = props => (
     <InputGroup disabled={props.disabled}>
         <LiveInput
             small
             disabled={props.disabled}
+            id={styles.strokeWidthIndicator}
             max={MAX_STROKE_WIDTH}
             min="0"
             type="number"


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/131

Happy to hear suggestions on how to improve the placement of this css

4rem comfortably fits the max value of 400
![image](https://user-images.githubusercontent.com/2855464/32454810-55cb6552-c2ee-11e7-854b-a10132396107.png)
