### PR TITLE
GH-131 Again: remove `small` from live inputs

### DIFF
--- a/src/components/forms/input.css
+++ b/src/components/forms/input.css
@@ -41,6 +41,6 @@ See https://github.com/LLK/scratch-paint/issues/13 */
 }
 
 .input-small {
-    width: 3.5rem; 
+    width: 3rem; 
     text-align: center;
 }

--- a/src/components/mode-tools/mode-tools.jsx
+++ b/src/components/mode-tools/mode-tools.jsx
@@ -65,7 +65,6 @@ const ModeToolsComponent = props => {
                     />
                 </div>
                 <LiveInput
-                    small
                     max={MAX_STROKE_WIDTH}
                     min="1"
                     type="number"
@@ -85,7 +84,6 @@ const ModeToolsComponent = props => {
                     />
                 </div>
                 <LiveInput
-                    small
                     max={MAX_STROKE_WIDTH}
                     min="1"
                     type="number"

--- a/src/components/stroke-width-indicator.jsx
+++ b/src/components/stroke-width-indicator.jsx
@@ -11,7 +11,6 @@ const LiveInput = LiveInputHOC(Input);
 const StrokeWidthIndicatorComponent = props => (
     <InputGroup disabled={props.disabled}>
         <LiveInput
-            small
             disabled={props.disabled}
             max={MAX_STROKE_WIDTH}
             min="0"


### PR DESCRIPTION
Fixes #131 by instead of changing the small width, simply just removing the small tag from things that don’t need it.