### PR TITLE
Clean up the scale tool

### DIFF
--- a/src/helper/guides.js
+++ b/src/helper/guides.js
@@ -84,8 +84,8 @@ const _removePaperItemsByTags = function (tags) {
     }
 };
 
-const removeHelperItems = function () {
-    _removePaperItemsByDataTags(['isHelperItem']);
+const removeBoundsPath = function () {
+    _removePaperItemsByDataTags(['isSelectionBound', 'isRotHandle', 'isScaleHandle']);
 };
 
 const removeAllGuides = function () {
@@ -113,7 +113,7 @@ export {
     hoverBounds,
     rectSelect,
     removeAllGuides,
-    removeHelperItems,
+    removeBoundsPath,
     drawHitPoint,
     removeHitPoint,
     getGuideColor,

--- a/src/helper/selection-tools/bounding-box-tool.js
+++ b/src/helper/selection-tools/bounding-box-tool.js
@@ -2,7 +2,7 @@ import paper from '@scratch/paper';
 import keyMirror from 'keymirror';
 
 import {getSelectedRootItems} from '../selection';
-import {getGuideColor, removeHelperItems} from '../guides';
+import {getGuideColor, removeBoundsPath} from '../guides';
 import {getGuideLayer} from '../layer';
 
 import ScaleTool from './scale-tool';
@@ -103,13 +103,12 @@ class BoundingBoxTool {
         if (this.mode === BoundingBoxModes.MOVE) {
             this._modeMap[this.mode].onMouseDown(hitProperties);
         } else if (this.mode === BoundingBoxModes.SCALE) {
-            this._modeMap[this.mode].onMouseDown(
-                hitResult, this.boundsPath, this.boundsScaleHandles, this.boundsRotHandles, getSelectedRootItems());
+            this._modeMap[this.mode].onMouseDown(hitResult, this.boundsPath, getSelectedRootItems());
         } else if (this.mode === BoundingBoxModes.ROTATE) {
             this._modeMap[this.mode].onMouseDown(hitResult, this.boundsPath, getSelectedRootItems());
         }
 
-        // while transforming object, never show the bounds stuff
+        // while transforming, don't show bounds
         this.removeBoundsPath();
         return true;
     }
@@ -150,7 +149,6 @@ class BoundingBoxTool {
         this.boundsPath.data.isSelectionBound = true;
         this.boundsPath.data.isHelperItem = true;
         this.boundsPath.fillColor = null;
-        this.boundsPath.strokeScaling = false;
         this.boundsPath.fullySelected = true;
         this.boundsPath.parent = getGuideLayer();
         
@@ -205,7 +203,7 @@ class BoundingBoxTool {
         }
     }
     removeBoundsPath () {
-        removeHelperItems();
+        removeBoundsPath();
         this.boundsPath = null;
         this.boundsScaleHandles.length = 0;
         this.boundsRotHandles.length = 0;

--- a/src/helper/selection.js
+++ b/src/helper/selection.js
@@ -12,7 +12,7 @@ import {getItemsCompoundPath, isCompoundPath, isCompoundPathChild} from './compo
  */
 const getItems = function (options) {
     const newMatcher = function (item) {
-        return !item.locked &&
+        return !(item instanceof paper.Layer) && !item.locked &&
             !(item.data && item.data.isHelperItem) &&
             (!options.match || options.match(item));
     };


### PR DESCRIPTION
- Scale tool was setting `strokeScaling` of whatever it touched to false. This was causing https://github.com/LLK/scratch-paint/issues/140.
- Once strokeScaling is added back in, it is apparent that setting `applyMatrix = false` had unwanted side effects. Strokes would appear to scale and then snap back to expected look on mouse up. This also caused an issue with how shapes with gradient fills were previewed (the gradient would not move with the shape). To fix this I added applyMatrix back in and changed how we apply scale transforms accordingly (keeping track of the current amount of transform so that we can apply the delta instead of the entire transform each time)
- Scale tool doesn't need access to bounding box tool internals because the bounding box is removed when the scale tool is activated (see comment "`// while transforming, don't show bounds`" in bounding box tool). Thus a lot of the code was unneeded because it did nothing
- `removeBoundsPath` was removing all helper items, not just bounds. The other helper items included the group that the scale tool makes to show a preview of the change (so the object we're scaling would disappear between mouse down and up). Fixed this to only remove bounds.
- Scale tool was recreating the group that was being scaled in every call to `onMouseDrag` (probably because it didn't work in `onMouseDown` because of the above bug.) Moved this to create it once in `onMouseDown`.