### PR TITLE
Do not use Object.values

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -165,7 +165,7 @@ PaperCanvas.propTypes = {
     clearPasteOffset: PropTypes.func.isRequired,
     clearSelectedItems: PropTypes.func.isRequired,
     clearUndo: PropTypes.func.isRequired,
-    mode: PropTypes.oneOf(Object.values(Modes)),
+    mode: PropTypes.oneOf(Object.keys(Modes)),
     onUpdateSvg: PropTypes.func.isRequired,
     rotationCenterX: PropTypes.number,
     rotationCenterY: PropTypes.number,


### PR DESCRIPTION
This is almost silly because the "keymirror" used to create the `Modes` object
actually ensures that the keys and the values of the object are the
same ([source](https://github.com/STRML/keyMirror/blob/master/index.js#L44-L48)). So replace `Object.values` with `Object.keys` which has complete
browser support.

Fixes https://github.com/LLK/scratch-gui/issues/863
Fixes https://github.com/LLK/scratch-paint/issues/193