### PR TITLE
Add canvas prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",
+    "canvas-prebuilt": "^1.6.5-prerelease.1",
     "classnames": "2.2.5",
     "css-loader": "0.28.3",
     "enzyme": "^3.1.0",


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/192

Any test that touches Paper fails with the following error:
Canvas [object HTMLCanvasElement] is unable to provide a 2D context.

canvas-prebuilt fixes these tests locally (at least for Ubuntu on Windows and Mac OSX). It doesn't fix the tests on Travis. 'npm install canvas' fixes the tests on Travis, but it breaks npm install locally, so the travis.yml script installs canvas on just Travis. See https://github.com/LLK/scratch-paint/pull/187