### PR TITLE
Remove "svg:" namespace from svg before importing.

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -81,6 +81,19 @@ class PaperCanvas extends React.Component {
     }
     importSvg (svg, rotationCenterX, rotationCenterY) {
         const paperCanvas = this;
+        // Pre-process SVG to prevent parsing errors (discussion from #213)
+        // 1. Remove newlines and tab characters, chrome will not load urls with them.
+        //      https://www.chromestatus.com/feature/5735596811091968
+        svg = svg.split(/[\n|\r|\t]/).join('');
+        // 2. Remove svg: namespace on elements.
+        svg = svg.split(/<\s*svg:/).join('<');
+        svg = svg.split(/<\/\s*svg:/).join('</');
+        // 3. Add root svg namespace if it does not exist.
+        const svgAttrs = svg.match(/<svg [^>]*>/);
+        if (svgAttrs && svgAttrs[0].indexOf('xmlns=') === -1) {
+            svg = svg.replace(
+                '<svg ', '<svg xmlns="http://www.w3.org/2000/svg" ');
+        }
         paper.project.importSVG(svg, {
             expandShapes: true,
             onLoad: function (item) {


### PR DESCRIPTION
The namespace on tags causes paperjs to fail to import.

Fixes https://github.com/LLK/scratch-paint/issues/209

