### PR TITLE
Pass bounds

### DIFF
--- a/src/helper/hover.js
+++ b/src/helper/hover.js
@@ -11,6 +11,7 @@ import {isGroupChild} from './group';
  * @return {paper.Item} the hovered item or null if there is none
  */
 const getHoveredItem = function (event, hitOptions, subselect) {
+    // @todo make hit test only hit painting layer
     const hitResults = paper.project.hitTestAll(event.point, hitOptions);
     if (hitResults.length === 0) {
         return null;

--- a/src/helper/selection-tools/bounding-box-tool.js
+++ b/src/helper/selection-tools/bounding-box-tool.js
@@ -150,16 +150,39 @@ class BoundingBoxTool {
         this.boundsPath.data.isSelectionBound = true;
         this.boundsPath.data.isHelperItem = true;
         this.boundsPath.fillColor = null;
-        this.boundsPath.fullySelected = true;
         this.boundsPath.parent = getGuideLayer();
+        this.boundsPath.strokeWidth = 1 / paper.view.zoom;
+        this.boundsPath.strokeColor = getGuideColor();
         
+        const boundsScaleCircleShadow =
+            new paper.Path.Circle({
+                center: new paper.Point(0, 0),
+                radius: 5.5 / paper.view.zoom,
+                fillColor: 'black',
+                opacity: .12,
+                data: {
+                    isHelperItem: true,
+                    noSelect: true,
+                    noHover: true
+                }
+            });
+        const boundsScaleCircle =
+            new paper.Path.Circle({
+                center: new paper.Point(0, 0),
+                radius: 4 / paper.view.zoom,
+                fillColor: getGuideColor(),
+                data: {
+                    isScaleHandle: true,
+                    isHelperItem: true,
+                    noSelect: true,
+                    noHover: true
+                }
+            });
+        const boundsScaleHandle = new paper.Group([boundsScaleCircleShadow, boundsScaleCircle]);
+        boundsScaleHandle.parent = getGuideLayer();
+
         for (let index = 0; index < this.boundsPath.segments.length; index++) {
             const segment = this.boundsPath.segments[index];
-            let size = 4;
-            
-            if (index % 2 === 0) {
-                size = 6;
-            }
             
             if (index === 7) {
                 const offset = new paper.Point(0, 20);
@@ -187,20 +210,18 @@ class BoundingBoxTool {
                 this.boundsRotHandles[index] = rotHandle;
             }
             
-            this.boundsScaleHandles[index] =
-                new paper.Path.Rectangle({
-                    center: segment.point,
-                    data: {
-                        index: index,
-                        isScaleHandle: true,
-                        isHelperItem: true,
-                        noSelect: true,
-                        noHover: true
-                    },
-                    size: [size / paper.view.zoom, size / paper.view.zoom],
-                    fillColor: getGuideColor(),
-                    parent: getGuideLayer()
-                });
+            this.boundsScaleHandles[index] = boundsScaleHandle.clone();
+            this.boundsScaleHandles[index].position = segment.point;
+            for (const child of this.boundsScaleHandles[index].children) {
+                child.data.index = index;
+            }
+            this.boundsScaleHandles[index].data = {
+                index: index,
+                isScaleHandle: true,
+                isHelperItem: true,
+                noSelect: true,
+                noHover: true
+            };
         }
     }
     removeBoundsPath () {

--- a/src/helper/selection-tools/bounding-box-tool.js
+++ b/src/helper/selection-tools/bounding-box-tool.js
@@ -154,6 +154,7 @@ class BoundingBoxTool {
         this.boundsPath.strokeWidth = 1 / paper.view.zoom;
         this.boundsPath.strokeColor = getGuideColor();
         
+        // Make a template to copy
         const boundsScaleCircleShadow =
             new paper.Path.Circle({
                 center: new paper.Point(0, 0),
@@ -223,6 +224,8 @@ class BoundingBoxTool {
                 noHover: true
             };
         }
+        // Remove the template
+        boundsScaleHandle.remove();
     }
     removeBoundsPath () {
         removeBoundsPath();

--- a/src/helper/selection-tools/bounding-box-tool.js
+++ b/src/helper/selection-tools/bounding-box-tool.js
@@ -103,9 +103,9 @@ class BoundingBoxTool {
         if (this.mode === BoundingBoxModes.MOVE) {
             this._modeMap[this.mode].onMouseDown(hitProperties);
         } else if (this.mode === BoundingBoxModes.SCALE) {
-            this._modeMap[this.mode].onMouseDown(hitResult, this.boundsPath, getSelectedRootItems());
+            this._modeMap[this.mode].onMouseDown(hitResult, this._getBounds(), getSelectedRootItems());
         } else if (this.mode === BoundingBoxModes.ROTATE) {
-            this._modeMap[this.mode].onMouseDown(hitResult, this.boundsPath, getSelectedRootItems());
+            this._modeMap[this.mode].onMouseDown(hitResult, this._getBounds(), getSelectedRootItems());
         }
 
         // While transforming, don't show bounds
@@ -124,13 +124,10 @@ class BoundingBoxTool {
         this.setSelectionBounds();
         this.mode = null;
     }
-    setSelectionBounds () {
-        this.removeBoundsPath();
-        
-        const items = getSelectedRootItems();
-        if (items.length <= 0) return;
-        
+    _getBounds () {
         let rect = null;
+        const items = getSelectedRootItems();
+        if (items.length <= 0) return null;
         for (const item of items) {
             if (rect) {
                 rect = rect.unite(item.bounds);
@@ -138,9 +135,15 @@ class BoundingBoxTool {
                 rect = item.bounds;
             }
         }
-        
+        return rect;
+    }
+    setSelectionBounds () {
+        this.removeBoundsPath();
+
+        const bounds = this._getBounds();
+        if (!bounds) return;
         if (!this.boundsPath) {
-            this.boundsPath = new paper.Path.Rectangle(rect);
+            this.boundsPath = new paper.Path.Rectangle(bounds);
             this.boundsPath.curves[0].divideAtTime(0.5);
             this.boundsPath.curves[2].divideAtTime(0.5);
             this.boundsPath.curves[4].divideAtTime(0.5);

--- a/src/helper/selection-tools/rotate-tool.js
+++ b/src/helper/selection-tools/rotate-tool.js
@@ -16,11 +16,11 @@ class RotateTool {
 
     /**
      * @param {!paper.HitResult} hitResult Data about the location of the mouse click
-     * @param {!object} boundsPath Where the boundaries of the hit item are
+     * @param {!object} bounds Where the boundaries of the hit item are
      * @param {!Array.<paper.Item>} selectedItems Set of selected paper.Items
      */
-    onMouseDown (hitResult, boundsPath, selectedItems) {
-        this.rotGroupPivot = boundsPath.bounds.center;
+    onMouseDown (hitResult, bounds, selectedItems) {
+        this.rotGroupPivot = bounds.center;
         for (const item of selectedItems) {
             // Rotate only root items
             if (item.parent instanceof paper.Layer) {

--- a/src/helper/selection-tools/scale-tool.js
+++ b/src/helper/selection-tools/scale-tool.js
@@ -23,16 +23,16 @@ class ScaleTool {
 
     /**
      * @param {!paper.HitResult} hitResult Data about the location of the mouse click
-     * @param {!object} boundsPath Where the boundaries of the hit item are
+     * @param {!object} bounds Where the boundaries of the hit item are, or null if no hit item.
      * @param {!Array.<paper.Item>} selectedItems Set of selected paper.Items
      */
-    onMouseDown (hitResult, boundsPath, selectedItems) {
+    onMouseDown (hitResult, bounds, selectedItems) {
         const index = hitResult.item.data.index;
-        this.pivot = boundsPath.bounds[this._getOpposingRectCornerNameByIndex(index)].clone();
-        this.origPivot = boundsPath.bounds[this._getOpposingRectCornerNameByIndex(index)].clone();
-        this.corner = boundsPath.bounds[this._getRectCornerNameByIndex(index)].clone();
+        this.pivot = bounds[this._getOpposingRectCornerNameByIndex(index)].clone();
+        this.origPivot = bounds[this._getOpposingRectCornerNameByIndex(index)].clone();
+        this.corner = bounds[this._getRectCornerNameByIndex(index)].clone();
         this.origSize = this.corner.subtract(this.pivot);
-        this.origCenter = boundsPath.bounds.center;
+        this.origCenter = bounds.center;
         this.centered = false;
         this.lastSx = 1;
         this.lastSy = 1;


### PR DESCRIPTION
Rather than passing the styled bounds path, pass just the rectangle of the selected item bounds to subtools in bounding box tool. We used to use other parts of the bounds path, but don't anymore.