### PR TITLE
Add missing code for updating stroke color from eyedropper

### DIFF
--- a/src/containers/stroke-color-indicator.jsx
+++ b/src/containers/stroke-color-indicator.jsx
@@ -13,7 +13,8 @@ class StrokeColorIndicator extends React.Component {
     constructor (props) {
         super(props);
         bindAll(this, [
-            'handleChangeStrokeColor'
+            'handleChangeStrokeColor',
+            'handleCloseStrokeColor'
         ]);
 
         // Flag to track whether an svg-update-worthy change has been made
@@ -33,11 +34,17 @@ class StrokeColorIndicator extends React.Component {
         this._hasChanged = this._hasChanged || isDifferent;
         this.props.onChangeStrokeColor(newColor);
     }
+    handleCloseStrokeColor () {
+        if (!this.props.isEyeDropping) {
+            this.props.onCloseStrokeColor();
+        }
+    }
     render () {
         return (
             <StrokeColorIndicatorComponent
                 {...this.props}
                 onChangeStrokeColor={this.handleChangeStrokeColor}
+                onCloseStrokeColor={this.handleCloseStrokeColor}
             />
         );
     }
@@ -45,6 +52,7 @@ class StrokeColorIndicator extends React.Component {
 
 const mapStateToProps = state => ({
     disabled: state.scratchPaint.mode === Modes.BRUSH,
+    isEyeDropping: state.scratchPaint.color.eyeDropper.active,
     strokeColor: state.scratchPaint.color.strokeColor,
     strokeColorModalVisible: state.scratchPaint.modals.strokeColor
 });
@@ -63,7 +71,9 @@ const mapDispatchToProps = dispatch => ({
 
 StrokeColorIndicator.propTypes = {
     disabled: PropTypes.bool.isRequired,
+    isEyeDropping: PropTypes.bool.isRequired,
     onChangeStrokeColor: PropTypes.func.isRequired,
+    onCloseStrokeColor: PropTypes.func.isRequired,
     onUpdateSvg: PropTypes.func.isRequired,
     strokeColor: PropTypes.string,
     strokeColorModalVisible: PropTypes.bool.isRequired


### PR DESCRIPTION
@mewtaylor looks like this code was missing from that eyedropper fix you made before the PR was merged. I just copied it over from the fill color container. 

Here is what it looks like on develop (eyedropper doesn't update the stage)
![not-working-stroke-eyedropper](https://user-images.githubusercontent.com/654102/34165495-754c3c20-e4aa-11e7-8a40-c49eab28e5f8.gif)

Here is what it does after the change (updates the stage) 
![working-stroke-eyedropper](https://user-images.githubusercontent.com/654102/34165516-803e9f92-e4aa-11e7-9f80-9836fcb31fc9.gif)
