### PR TITLE
Don't change opposite handle length when changing handle length

### DIFF
--- a/src/helper/selection-tools/handle-tool.js
+++ b/src/helper/selection-tools/handle-tool.js
@@ -30,7 +30,7 @@ class HandleTool {
     }
     onMouseDrag (event) {
         this.selectedItems = getSelectedLeafItems();
-        
+
         for (const item of this.selectedItems) {
             for (const seg of item.segments) {
                 // add the point of the segment before the drag started
@@ -46,9 +46,8 @@ class HandleTool {
                         !seg.handleOut.isColinear(seg.handleIn)) {
                         seg.handleOut = seg.handleOut.add(event.delta);
                     } else {
-                        const oldLength = seg.handleOut.length;
                         seg.handleOut = seg.handleOut.add(event.delta);
-                        seg.handleIn = seg.handleOut.multiply(-seg.handleIn.length / oldLength);
+                        seg.handleIn = seg.handleOut.multiply(-seg.handleIn.length / seg.handleOut.length);
                     }
                 } else if (seg.handleIn.selected && this.hitType === 'handle-in') {
                     // if option is pressed or handles have been split,
@@ -58,9 +57,8 @@ class HandleTool {
                         seg.handleIn = seg.handleIn.add(event.delta);
 
                     } else {
-                        const oldLength = seg.handleIn.length;
                         seg.handleIn = seg.handleIn.add(event.delta);
-                        seg.handleOut = seg.handleIn.multiply(-seg.handleOut.length / oldLength);
+                        seg.handleOut = seg.handleIn.multiply(-seg.handleOut.length / seg.handleIn.length);
                     }
                 }
             }


### PR DESCRIPTION
Before, you would get stuck in situations like this, where it's very hard to manipulate a curve with uneven handles:
![handle](https://user-images.githubusercontent.com/2855464/34219537-7c427ad2-e57f-11e7-923e-919e5ba3c390.gif)
After:
![handle2](https://user-images.githubusercontent.com/2855464/34219543-8131c05c-e57f-11e7-9baf-929ae7960a9d.gif)

/cc @carljbowman 