### PR TITLE
Fix GH-226: set enterExitTransitionDurationMs to imperceptibly small value

### DIFF
--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -246,7 +246,7 @@ const PaintEditorComponent = props => {
                             <InputGroup>
                                 <Dropdown
                                     className={styles.modUnselect}
-                                    enterExitTransitionDurationMs={0}
+                                    enterExitTransitionDurationMs={20}
                                     popoverContent={
                                         <InputGroup className={styles.modContextMenu}>
                                             <Button


### PR DESCRIPTION
#226 appears to be caused when the duration in ms is below a certain value, which is why we don’t see it in other popovers. I’m not sure exactly what may be causing this in the `react-popover` library and will open an issue about it, but for now, 20ms is imperceptibly fast, and appears to remove the error.