### PR TITLE
Clean up the cursor preview when it is removed from its parent

### DIFF
--- a/src/helper/blob-tools/blob.js
+++ b/src/helper/blob-tools/blob.js
@@ -163,7 +163,12 @@ class Blobbiness {
         if (!this.options) {
             return;
         }
-        if (this.cursorPreview && this.cursorPreview.parent &&
+        // The cursor preview was unattached from the view by an outside process,
+        // such as changing costumes or undo.
+        if (this.cursorPreview && !this.cursorPreview.parent) {
+            this.cursorPreview = null;
+        }
+        if (this.cursorPreview &&
                 this.brushSize === this.options.brushSize &&
                 this.fillColor === this.options.fillColor &&
                 this.strokeColor === this.options.strokeColor &&


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/225