### PR TITLE
Add an initial undo state when importing a blank costume

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -63,6 +63,8 @@ class PaperCanvas extends React.Component {
             paper.project.view.zoom = oldZoom;
             paper.project.view.center = oldCenter;
             paper.project.view.update();
+        } else {
+            performSnapshot(this.props.undoSnapshot);
         }
     }
     componentWillUnmount () {


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/253

The first undo state is considered the initial state and is not undoable. Add the initial snapshot for blank SVGs.