### PR TITLE
Add holding shift to force horizontal scrolling

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -164,7 +164,7 @@ class PaperCanvas extends React.Component {
                 new paper.Point(offsetX, offsetY)
             );
             zoomOnFixedPoint(-event.deltaY / 100, fixedPoint);
-        } else if (event.shiftKey) {
+        } else if (event.shiftKey && event.deltaX === 0) {
             // Scroll horizontally (based on vertical scroll delta)
             // This is needed as for some browser/system combinations which do not set deltaX.
             // See #156.

--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -164,6 +164,12 @@ class PaperCanvas extends React.Component {
                 new paper.Point(offsetX, offsetY)
             );
             zoomOnFixedPoint(-event.deltaY / 100, fixedPoint);
+        } else if (event.shiftKey) {
+            // Scroll horizontally (based on vertical scroll delta)
+            // This is needed as for some browser/system combinations which do not set deltaX.
+            // See #156.
+            const dx = event.deltaY / paper.project.view.zoom;
+            pan(dx, 0);
         } else {
             const dx = event.deltaX / paper.project.view.zoom;
             const dy = event.deltaY / paper.project.view.zoom;


### PR DESCRIPTION
Fixes #156.

This is a "workaround" for browsers which do not automatically set `deltaX` when the shift key is held (seen on Firefox-Linux and Chrome-Windows, but not Chrome-Mac). This PR makes it so that when the shift key is held while scrolling, `deltaX` is ignored, and the distance scrolled horizontally is set to `deltaY`.

This might have a strange effect on macbooks with trackpads (suddenly the distance you move your fingers left/right has no effect and horizontal scrolling is based on up/down finger movement), but I think that's acceptable - it would be obvious that it only behaves that way when shift is held, and wouldn't be too difficult to intuit anyways.

Tested locally on Firefox/Linux.