### PR TITLE
Use sans-serif font in playground

### DIFF
--- a/src/playground/index.ejs
+++ b/src/playground/index.ejs
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%= htmlWebpackPlugin.options.title %></title>
+    <style>body { font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; }</style>
   </head>
   <body>
   </body>

--- a/src/playground/index.ejs
+++ b/src/playground/index.ejs
@@ -4,7 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%= htmlWebpackPlugin.options.title %></title>
-    <style>body { font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; }</style>
+    <style>
+      body {
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      }
+    </style>
   </head>
   <body>
   </body>


### PR DESCRIPTION
Changes the playground body font to the Helvetica stack.

Before there were some cascade issues where you'd see default fonts in components (i.e. serif). This change is **only for the playground** as, I imagine, in scratch-3.0 this font style would be inherited from somewhere there.

Before (firefox-linux):
![image](https://user-images.githubusercontent.com/9429556/35193378-5eed40b0-fe99-11e7-8a90-9e53efaafe82.png)

After:
![image](https://user-images.githubusercontent.com/9429556/35193375-54523430-fe99-11e7-9316-0daffe35a0ca.png)
