### PR TITLE
Use translate instead of position for costume centering

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -131,13 +131,12 @@ class PaperCanvas extends React.Component {
                 ensureClockwise(item);
 
                 if (typeof rotationCenterX !== 'undefined' && typeof rotationCenterY !== 'undefined') {
-                    item.position =
-                        paper.project.view.center
-                            .add(itemWidth / 2, itemHeight / 2)
-                            .subtract(rotationCenterX, rotationCenterY);
+                    item.translate(paper.project.view.center
+                            .subtract(rotationCenterX, rotationCenterY));
                 } else {
                     // Center
-                    item.position = paper.project.view.center;
+                    item.translate(paper.project.view.center
+                            .subtract(itemWidth / 2, itemHeight / 2));
                 }
                 if (isGroup(item)) {
                     ungroupItems([item]);

--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -132,11 +132,11 @@ class PaperCanvas extends React.Component {
 
                 if (typeof rotationCenterX !== 'undefined' && typeof rotationCenterY !== 'undefined') {
                     item.translate(paper.project.view.center
-                            .subtract(rotationCenterX, rotationCenterY));
+                        .subtract(rotationCenterX, rotationCenterY));
                 } else {
                     // Center
                     item.translate(paper.project.view.center
-                            .subtract(itemWidth / 2, itemHeight / 2));
+                        .subtract(itemWidth / 2, itemHeight / 2));
                 }
                 if (isGroup(item)) {
                     ungroupItems([item]);


### PR DESCRIPTION
This fixes the centering of some sprites, most notably the refrigerator backdrop, but also some sprites where the center seemed to move around in paint but not on the stage. The issue was that item.position changes when the viewbox is removed, so we want to use translate instead.

before:
![centering_before](https://user-images.githubusercontent.com/2855464/35296967-97caf31a-004b-11e8-8981-30152c0759bc.gif)

after:
![centering](https://user-images.githubusercontent.com/2855464/35296976-9db62cae-004b-11e8-9fd5-923c4ead6581.gif)
