### PR TITLE
Flip all

### DIFF
--- a/src/components/mode-tools/mode-tools.jsx
+++ b/src/components/mode-tools/mode-tools.jsx
@@ -151,13 +151,11 @@ const ModeToolsComponent = props => {
                 </InputGroup>
                 <InputGroup className={classNames(styles.modLabeledIconHeight)}>
                     <LabeledIconButton
-                        disabled={!props.selectedItems.length}
                         imgSrc={flipHorizontalIcon}
                         title={props.intl.formatMessage(messages.flipHorizontal)}
                         onClick={props.onFlipHorizontal}
                     />
                     <LabeledIconButton
-                        disabled={!props.selectedItems.length}
                         imgSrc={flipVerticalIcon}
                         title={props.intl.formatMessage(messages.flipVertical)}
                         onClick={props.onFlipVertical}

--- a/src/components/mode-tools/mode-tools.jsx
+++ b/src/components/mode-tools/mode-tools.jsx
@@ -151,13 +151,11 @@ const ModeToolsComponent = props => {
                 </InputGroup>
                 <InputGroup className={classNames(styles.modLabeledIconHeight)}>
                     <LabeledIconButton
-                        disabled={!props.hasItems}
                         imgSrc={flipHorizontalIcon}
                         title={props.intl.formatMessage(messages.flipHorizontal)}
                         onClick={props.onFlipHorizontal}
                     />
                     <LabeledIconButton
-                        disabled={!props.hasItems}
                         imgSrc={flipVerticalIcon}
                         title={props.intl.formatMessage(messages.flipVertical)}
                         onClick={props.onFlipVertical}
@@ -178,7 +176,6 @@ ModeToolsComponent.propTypes = {
     className: PropTypes.string,
     clipboardItems: PropTypes.arrayOf(PropTypes.array),
     eraserValue: PropTypes.number,
-    hasItems: PropTypes.bool,
     hasSelectedUncurvedPoints: PropTypes.bool,
     hasSelectedUnpointedPoints: PropTypes.bool,
     intl: intlShape.isRequired,

--- a/src/components/mode-tools/mode-tools.jsx
+++ b/src/components/mode-tools/mode-tools.jsx
@@ -151,11 +151,13 @@ const ModeToolsComponent = props => {
                 </InputGroup>
                 <InputGroup className={classNames(styles.modLabeledIconHeight)}>
                     <LabeledIconButton
+                        disabled={!props.hasItems}
                         imgSrc={flipHorizontalIcon}
                         title={props.intl.formatMessage(messages.flipHorizontal)}
                         onClick={props.onFlipHorizontal}
                     />
                     <LabeledIconButton
+                        disabled={!props.hasItems}
                         imgSrc={flipVerticalIcon}
                         title={props.intl.formatMessage(messages.flipVertical)}
                         onClick={props.onFlipVertical}
@@ -176,6 +178,7 @@ ModeToolsComponent.propTypes = {
     className: PropTypes.string,
     clipboardItems: PropTypes.arrayOf(PropTypes.array),
     eraserValue: PropTypes.number,
+    hasItems: PropTypes.bool,
     hasSelectedUncurvedPoints: PropTypes.bool,
     hasSelectedUnpointedPoints: PropTypes.bool,
     intl: intlShape.isRequired,

--- a/src/containers/mode-tools.jsx
+++ b/src/containers/mode-tools.jsx
@@ -138,11 +138,9 @@ class ModeTools extends React.Component {
     }
     _handleFlip (horizontalScale, verticalScale) {
         let selectedItems = getSelectedRootItems();
-        let center;
         if (selectedItems.length === 0) {
-            // If nothing is selected, flip everything over the rotation point
+            // If nothing is selected, select everything
             selectedItems = getAllRootItems();
-            center = paper.view.center;
         }
         // Record old indices
         for (const item of selectedItems) {
@@ -152,7 +150,7 @@ class ModeTools extends React.Component {
         // Group items so that they flip as a unit
         const itemGroup = new paper.Group(selectedItems);
         // Flip
-        itemGroup.scale(horizontalScale, verticalScale, center);
+        itemGroup.scale(horizontalScale, verticalScale);
         ensureClockwise(itemGroup);
 
         // Remove flipped item from group and insert at old index. Must insert from bottom index up.

--- a/src/containers/mode-tools.jsx
+++ b/src/containers/mode-tools.jsx
@@ -7,8 +7,7 @@ import bindAll from 'lodash.bindall';
 import ModeToolsComponent from '../components/mode-tools/mode-tools.jsx';
 import {clearSelectedItems, setSelectedItems} from '../reducers/selected-items';
 import {incrementPasteOffset, setClipboardItems} from '../reducers/clipboard';
-import {clearSelection, getSelectedLeafItems, getSelectedRootItems} from '../helper/selection';
-import {getAllRootItems, getAllSelectableRootItems} from '../helper/selection';
+import {clearSelection, getSelectedLeafItems, getSelectedRootItems, getAllRootItems} from '../helper/selection';
 import {HANDLE_RATIO, ensureClockwise} from '../helper/math';
 
 class ModeTools extends React.Component {
@@ -17,7 +16,6 @@ class ModeTools extends React.Component {
         bindAll(this, [
             '_getSelectedUncurvedPoints',
             '_getSelectedUnpointedPoints',
-            'hasItems',
             'hasSelectedUncurvedPoints',
             'hasSelectedUnpointedPoints',
             'handleCopyToClipboard',
@@ -69,9 +67,6 @@ class ModeTools extends React.Component {
     hasSelectedUnpointedPoints () {
         const points = this._getSelectedUnpointedPoints();
         return points.length > 0;
-    }
-    hasItems () {
-        return getAllSelectableRootItems().length > 0;
     }
     handleCurvePoints () {
         let changed;
@@ -208,7 +203,6 @@ class ModeTools extends React.Component {
     render () {
         return (
             <ModeToolsComponent
-                hasItems={this.hasItems()}
                 hasSelectedUncurvedPoints={this.hasSelectedUncurvedPoints()}
                 hasSelectedUnpointedPoints={this.hasSelectedUnpointedPoints()}
                 onCopyToClipboard={this.handleCopyToClipboard}

--- a/src/containers/mode-tools.jsx
+++ b/src/containers/mode-tools.jsx
@@ -7,7 +7,8 @@ import bindAll from 'lodash.bindall';
 import ModeToolsComponent from '../components/mode-tools/mode-tools.jsx';
 import {clearSelectedItems, setSelectedItems} from '../reducers/selected-items';
 import {incrementPasteOffset, setClipboardItems} from '../reducers/clipboard';
-import {clearSelection, getSelectedLeafItems, getSelectedRootItems, getAllRootItems} from '../helper/selection';
+import {clearSelection, getSelectedLeafItems, getSelectedRootItems} from '../helper/selection';
+import {getAllRootItems, getAllSelectableRootItems} from '../helper/selection';
 import {HANDLE_RATIO, ensureClockwise} from '../helper/math';
 
 class ModeTools extends React.Component {
@@ -16,6 +17,7 @@ class ModeTools extends React.Component {
         bindAll(this, [
             '_getSelectedUncurvedPoints',
             '_getSelectedUnpointedPoints',
+            'hasItems',
             'hasSelectedUncurvedPoints',
             'hasSelectedUnpointedPoints',
             'handleCopyToClipboard',
@@ -67,6 +69,9 @@ class ModeTools extends React.Component {
     hasSelectedUnpointedPoints () {
         const points = this._getSelectedUnpointedPoints();
         return points.length > 0;
+    }
+    hasItems () {
+        return getAllSelectableRootItems().length > 0;
     }
     handleCurvePoints () {
         let changed;
@@ -203,6 +208,7 @@ class ModeTools extends React.Component {
     render () {
         return (
             <ModeToolsComponent
+                hasItems={this.hasItems()}
                 hasSelectedUncurvedPoints={this.hasSelectedUncurvedPoints()}
                 hasSelectedUnpointedPoints={this.hasSelectedUnpointedPoints()}
                 onCopyToClipboard={this.handleCopyToClipboard}

--- a/src/containers/mode-tools.jsx
+++ b/src/containers/mode-tools.jsx
@@ -7,7 +7,7 @@ import bindAll from 'lodash.bindall';
 import ModeToolsComponent from '../components/mode-tools/mode-tools.jsx';
 import {clearSelectedItems, setSelectedItems} from '../reducers/selected-items';
 import {incrementPasteOffset, setClipboardItems} from '../reducers/clipboard';
-import {clearSelection, getSelectedLeafItems, getSelectedRootItems} from '../helper/selection';
+import {clearSelection, getSelectedLeafItems, getSelectedRootItems, getAllRootItems} from '../helper/selection';
 import {HANDLE_RATIO, ensureClockwise} from '../helper/math';
 
 class ModeTools extends React.Component {
@@ -137,7 +137,13 @@ class ModeTools extends React.Component {
         }
     }
     _handleFlip (horizontalScale, verticalScale) {
-        const selectedItems = getSelectedRootItems();
+        let selectedItems = getSelectedRootItems();
+        let center;
+        if (selectedItems.length === 0) {
+            // If nothing is selected, flip everything over the rotation point
+            selectedItems = getAllRootItems();
+            center = paper.view.center;
+        }
         // Record old indices
         for (const item of selectedItems) {
             item.data.index = item.index;
@@ -146,7 +152,7 @@ class ModeTools extends React.Component {
         // Group items so that they flip as a unit
         const itemGroup = new paper.Group(selectedItems);
         // Flip
-        itemGroup.scale(horizontalScale, verticalScale);
+        itemGroup.scale(horizontalScale, verticalScale, center);
         ensureClockwise(itemGroup);
 
         // Remove flipped item from group and insert at old index. Must insert from bottom index up.

--- a/src/helper/selection.js
+++ b/src/helper/selection.js
@@ -400,6 +400,7 @@ const shouldShowSelectAll = function () {
 export {
     getItems,
     getAllRootItems,
+    getAllSelectableRootItems,
     selectAllItems,
     selectAllSegments,
     clearSelection,

--- a/src/helper/selection.js
+++ b/src/helper/selection.js
@@ -400,7 +400,6 @@ const shouldShowSelectAll = function () {
 export {
     getItems,
     getAllRootItems,
-    getAllSelectableRootItems,
     selectAllItems,
     selectAllSegments,
     clearSelection,


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/247

When nothing is selected, flip everything in the paint editor over the rotation point.
![flipall](https://user-images.githubusercontent.com/2855464/35400100-e9a36f22-01c3-11e8-8767-91bb9445ef3c.gif)
