### PR TITLE
Nudge

### DIFF
--- a/src/helper/selection-tools/nudge-tool.js
+++ b/src/helper/selection-tools/nudge-tool.js
@@ -1,0 +1,50 @@
+import {getSelectedRootItems} from '../selection';
+import paper from '@scratch/paper';
+
+/**
+ * Tool containing handlers for arrow key events for nudging the selection.
+ * Note that this tool is built for selection mode, not reshape mode.
+ */
+class NudgeTool {
+    /**
+     * @param {function} boundingBoxTool to control the bounding box
+     * @param {!function} onUpdateSvg A callback to call when the image visibly changes
+     */
+    constructor (boundingBoxTool, onUpdateSvg) {
+        this.boundingBoxTool = boundingBoxTool;
+        this.onUpdateSvg = onUpdateSvg;
+    }
+    onKeyDown (event) {
+        const nudgeAmount = 1 / paper.view.zoom;
+        const selected = getSelectedRootItems();
+        if (selected.length === 0) return;
+
+        let translation;
+        if (event.key === 'up') {
+            translation = new paper.Point(0, -nudgeAmount);
+        } else if (event.key === 'down') {
+            translation = new paper.Point(0, nudgeAmount);
+        } else if (event.key === 'left') {
+            translation = new paper.Point(-nudgeAmount, 0);
+        } else if (event.key === 'right') {
+            translation = new paper.Point(nudgeAmount, 0);
+        }
+
+        if (translation) {
+            for (const item of selected) {
+                item.translate(translation);
+            }
+        }
+        this.boundingBoxTool.setSelectionBounds();
+    }
+    onKeyUp (event) {
+        const selected = getSelectedRootItems();
+        if (selected.length === 0) return;
+
+        if (event.key === 'up' || event.key === 'down' || event.key === 'left' || event.key === 'right') {
+            this.onUpdateSvg();
+        }
+    }
+}
+
+export default NudgeTool;

--- a/src/helper/selection-tools/select-tool.js
+++ b/src/helper/selection-tools/select-tool.js
@@ -1,8 +1,9 @@
 import Modes from '../../lib/modes';
 
 import {getHoveredItem} from '../hover';
-import {getSelectedRootItems, selectRootItem} from '../selection';
+import {selectRootItem} from '../selection';
 import BoundingBoxTool from './bounding-box-tool';
+import NudgeTool from './nudge-tool';
 import SelectionBoxTool from './selection-box-tool';
 import paper from '@scratch/paper';
 
@@ -31,6 +32,7 @@ class SelectTool extends paper.Tool {
         this.clearHoveredItem = clearHoveredItem;
         this.onUpdateSvg = onUpdateSvg;
         this.boundingBoxTool = new BoundingBoxTool(Modes.SELECT, setSelectedItems, clearSelectedItems, onUpdateSvg);
+        const nudgeTool = new NudgeTool(this.boundingBoxTool, onUpdateSvg);
         this.selectionBoxTool = new SelectionBoxTool(Modes.SELECT, setSelectedItems, clearSelectedItems);
         this.selectionBoxMode = false;
         this.prevHoveredItemId = null;
@@ -42,8 +44,8 @@ class SelectTool extends paper.Tool {
         this.onMouseMove = this.handleMouseMove;
         this.onMouseDrag = this.handleMouseDrag;
         this.onMouseUp = this.handleMouseUp;
-        this.onKeyUp = this.handleKeyUp;
-        this.onKeyDown = this.handleKeyDown;
+        this.onKeyUp = nudgeTool.onKeyUp;
+        this.onKeyDown = nudgeTool.onKeyDown;
 
         selectRootItem();
         setSelectedItems();
@@ -132,37 +134,6 @@ class SelectTool extends paper.Tool {
         }
         this.selectionBoxMode = false;
         this.active = false;
-    }
-    handleKeyDown (event) {
-        const nudgeAmount = 1 / paper.view.zoom;
-        const selected = getSelectedRootItems();
-        if (selected.length === 0) return;
-
-        let translation;
-        if (event.key === 'up') {
-            translation = new paper.Point(0, -nudgeAmount);
-        } else if (event.key === 'down') {
-            translation = new paper.Point(0, nudgeAmount);
-        } else if (event.key === 'left') {
-            translation = new paper.Point(-nudgeAmount, 0);
-        } else if (event.key === 'right') {
-            translation = new paper.Point(nudgeAmount, 0);
-        }
-
-        if (translation) {
-            for (const item of selected) {
-                item.translate(translation);
-            }
-        }
-        this.boundingBoxTool.setSelectionBounds();
-    }
-    handleKeyUp (event) {
-        const selected = getSelectedRootItems();
-        if (selected.length === 0) return;
-
-        if (event.key === 'up' || event.key === 'down' || event.key === 'left' || event.key === 'right') {
-            this.onUpdateSvg();
-        }
     }
     deactivateTool () {
         this.clearHoveredItem();

--- a/src/helper/selection-tools/select-tool.js
+++ b/src/helper/selection-tools/select-tool.js
@@ -1,7 +1,7 @@
 import Modes from '../../lib/modes';
 
 import {getHoveredItem} from '../hover';
-import {selectRootItem} from '../selection';
+import {getSelectedRootItems, selectRootItem} from '../selection';
 import BoundingBoxTool from './bounding-box-tool';
 import SelectionBoxTool from './selection-box-tool';
 import paper from '@scratch/paper';
@@ -42,6 +42,8 @@ class SelectTool extends paper.Tool {
         this.onMouseMove = this.handleMouseMove;
         this.onMouseDrag = this.handleMouseDrag;
         this.onMouseUp = this.handleMouseUp;
+        this.onKeyUp = this.handleKeyUp;
+        this.onKeyDown = this.handleKeyDown;
 
         selectRootItem();
         setSelectedItems();
@@ -130,6 +132,37 @@ class SelectTool extends paper.Tool {
         }
         this.selectionBoxMode = false;
         this.active = false;
+    }
+    handleKeyDown (event) {
+        const nudgeAmount = 1 / paper.view.zoom;
+        const selected = getSelectedRootItems();
+        if (selected.length === 0) return;
+
+        let translation;
+        if (event.key === 'up') {
+            translation = new paper.Point(0, -nudgeAmount);
+        } else if (event.key === 'down') {
+            translation = new paper.Point(0, nudgeAmount);
+        } else if (event.key === 'left') {
+            translation = new paper.Point(-nudgeAmount, 0);
+        } else if (event.key === 'right') {
+            translation = new paper.Point(nudgeAmount, 0);
+        }
+
+        if (translation) {
+            for (const item of selected) {
+                item.translate(translation);
+            }
+        }
+        this.boundingBoxTool.setSelectionBounds();
+    }
+    handleKeyUp (event) {
+        const selected = getSelectedRootItems();
+        if (selected.length === 0) return;
+
+        if (event.key === 'up' || event.key === 'down' || event.key === 'left' || event.key === 'right') {
+            this.onUpdateSvg();
+        }
     }
     deactivateTool () {
         this.clearHoveredItem();

--- a/src/helper/selection.js
+++ b/src/helper/selection.js
@@ -175,6 +175,26 @@ const getSelectedLeafItems = function () {
     return items;
 };
 
+/**
+ * This gets all selected path segments.
+ * @return {Array<paper.Segment>} selected segments
+ */
+const getSelectedSegments = function () {
+    const selected = getSelectedLeafItems();
+    const segments = [];
+    for (const item of selected) {
+        if (!item.segments) {
+            continue;
+        }
+        for (const seg of item.segments) {
+            if (seg.selected) {
+                segments.push(seg);
+            }
+        }
+    }
+    return segments;
+};
+
 const _deleteItemSelection = function (items, onUpdateSvg) {
     // @todo: Update toolbar state on change
     if (items.length === 0) {
@@ -408,6 +428,7 @@ export {
     setItemSelection,
     getSelectedLeafItems,
     getSelectedRootItems,
+    getSelectedSegments,
     processRectangularSelection,
     selectRootItem,
     shouldShowSelectAll

--- a/src/helper/tools/oval-tool.js
+++ b/src/helper/tools/oval-tool.js
@@ -3,6 +3,7 @@ import Modes from '../../lib/modes';
 import {styleShape} from '../style-path';
 import {clearSelection} from '../selection';
 import BoundingBoxTool from '../selection-tools/bounding-box-tool';
+import NudgeTool from '../selection-tools/nudge-tool';
 
 /**
  * Tool for drawing ovals.
@@ -22,13 +23,15 @@ class OvalTool extends paper.Tool {
         this.clearSelectedItems = clearSelectedItems;
         this.onUpdateSvg = onUpdateSvg;
         this.boundingBoxTool = new BoundingBoxTool(Modes.OVAL, setSelectedItems, clearSelectedItems, onUpdateSvg);
+        const nudgeTool = new NudgeTool(this.boundingBoxTool, onUpdateSvg);
         
         // We have to set these functions instead of just declaring them because
         // paper.js tools hook up the listeners in the setter functions.
         this.onMouseDown = this.handleMouseDown;
         this.onMouseDrag = this.handleMouseDrag;
         this.onMouseUp = this.handleMouseUp;
-        this.onKeyUp = this.handleKeyUp;
+        this.onKeyUp = nudgeTool.onKeyUp;
+        this.onKeyDown = nudgeTool.onKeyDown;
 
         this.oval = null;
         this.colorState = null;

--- a/src/helper/tools/rect-tool.js
+++ b/src/helper/tools/rect-tool.js
@@ -3,6 +3,7 @@ import Modes from '../../lib/modes';
 import {styleShape} from '../style-path';
 import {clearSelection} from '../selection';
 import BoundingBoxTool from '../selection-tools/bounding-box-tool';
+import NudgeTool from '../selection-tools/nudge-tool';
 
 /**
  * Tool for drawing rectangles.
@@ -22,12 +23,15 @@ class RectTool extends paper.Tool {
         this.clearSelectedItems = clearSelectedItems;
         this.onUpdateSvg = onUpdateSvg;
         this.boundingBoxTool = new BoundingBoxTool(Modes.RECT, setSelectedItems, clearSelectedItems, onUpdateSvg);
+        const nudgeTool = new NudgeTool(this.boundingBoxTool, onUpdateSvg);
         
         // We have to set these functions instead of just declaring them because
         // paper.js tools hook up the listeners in the setter functions.
         this.onMouseDown = this.handleMouseDown;
         this.onMouseDrag = this.handleMouseDrag;
         this.onMouseUp = this.handleMouseUp;
+        this.onKeyUp = nudgeTool.onKeyUp;
+        this.onKeyDown = nudgeTool.onKeyDown;
 
         this.rect = null;
         this.colorState = null;


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/236
- getSelectedSegments is broken out since it's shared by point tool and reshape tool
- nudge-tool is broken out since it's shared by select-tool, oval-tool and rect-tool

Use arrow keys in select modes to nudge
![nudge](https://user-images.githubusercontent.com/2855464/35413793-940eb3ac-01ee-11e8-94bb-1747dee26aa3.gif)
