### PR TITLE
Temporary fix for eyedropper issue in Chrome 64

### DIFF
--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -176,6 +176,7 @@ class PaintEditor extends React.Component {
                 this.eyeDropper.pickY,
                 this.eyeDropper.hideLoupe
             );
+            if (!colorInfo) return;
             if (
                 this.state.colorInfo === null ||
                 this.state.colorInfo.x !== colorInfo.x ||


### PR DESCRIPTION
Buffer the paper canvas offscreen for picking to ensure safe access.

This gets around the bug #276 where chrome cannot handle getImageData
off a canvas on HDPI screens. In the interest of having a single
code-path, and because does not impose a large performance burden, I
think we should just use it for all platforms until chrome is really
fixed.

Also it is important to note that because this bug has to do with how
they handle accelerated 2d canvas contexts, it does not impact the stage
color picking, so that does not need to be changed.

The early returns I added are because the `getColorInfo` now potentially
returns null if the buffered image has not been loaded yet.