### PR TITLE
Fix bounding box issue when using shift+drag

### DIFF
--- a/src/helper/selection-tools/nudge-tool.js
+++ b/src/helper/selection-tools/nudge-tool.js
@@ -34,8 +34,8 @@ class NudgeTool {
             for (const item of selected) {
                 item.translate(translation);
             }
+            this.boundingBoxTool.setSelectionBounds();
         }
-        this.boundingBoxTool.setSelectionBounds();
     }
     onKeyUp (event) {
         const selected = getSelectedRootItems();


### PR DESCRIPTION
Only update the selection bounds if a nudge actually occurs

This was causing the problem where holding shift while dragging would
trigger the selection box to be shown, interrupting the drag.

Fixes the dragging part of https://github.com/LLK/scratch-paint/issues/278, but not the rotation part.