### PR TITLE
Don't nudge selection when input is focused

### DIFF
--- a/src/helper/selection-tools/nudge-tool.js
+++ b/src/helper/selection-tools/nudge-tool.js
@@ -15,8 +15,10 @@ class NudgeTool {
         this.onUpdateSvg = onUpdateSvg;
     }
     onKeyDown (event) {
-        // Bail if the real event target is an input
-        if (event.event.target.tagName === 'INPUT') return;
+        if (event.event.target instanceof HTMLInputElement) {
+            // Ignore nudge if a text input field is focused
+            return;
+        }
 
         const nudgeAmount = 1 / paper.view.zoom;
         const selected = getSelectedRootItems();

--- a/src/helper/selection-tools/nudge-tool.js
+++ b/src/helper/selection-tools/nudge-tool.js
@@ -15,6 +15,9 @@ class NudgeTool {
         this.onUpdateSvg = onUpdateSvg;
     }
     onKeyDown (event) {
+        // Bail if the real event target is an input
+        if (event.event.target.tagName === 'INPUT') return;
+
         const nudgeAmount = 1 / paper.view.zoom;
         const selected = getSelectedRootItems();
         if (selected.length === 0) return;


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/280

@carljbowman @fsih  I think we should talk in person about whether it is ok to bring this in without also doing https://github.com/LLK/scratch-paint/issues/282, which might cause a lot of frustration. The opposite might be a better short-term fix (make the input a "text" type so that it doesn't respond to keyboard controls, allowing the nudge tool to work despite the focus). The reason for that is I think #282 is going to be much more complicated to solve. 

@fsih I'll tag this needs-discussion until we actually talk about it, so no need to review it before then.