### PR TITLE
Change pan/zoom bounds to 360/480 to match the real bounds.

### DIFF
--- a/src/helper/view.js
+++ b/src/helper/view.js
@@ -9,11 +9,11 @@ const clampViewBounds = () => {
     if (top < 0) {
         paper.project.view.scrollBy(new paper.Point(0, -top));
     }
-    if (bottom > 400) {
-        paper.project.view.scrollBy(new paper.Point(0, 400 - bottom));
+    if (bottom > 360) {
+        paper.project.view.scrollBy(new paper.Point(0, 360 - bottom));
     }
-    if (right > 500) {
-        paper.project.view.scrollBy(new paper.Point(500 - right, 0));
+    if (right > 480) {
+        paper.project.view.scrollBy(new paper.Point(480 - right, 0));
     }
 };
 


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/223 a bug where you can scroll the paint editor outside the 480/360 bounds because it allows you to go to 500/400. 

I know this will be fixed with the other scrollbar work, it just was a thorn in my side that you could still do this, and it is such a simple fix 💯 

You can no longer do this:
![image](https://user-images.githubusercontent.com/654102/35976155-3a61d4e6-0cad-11e8-9ae7-5a31230b1ffb.png)
