### PR TITLE
Mark all clickable images as not draggable.

### DIFF
--- a/src/components/color-button/color-button.jsx
+++ b/src/components/color-button/color-button.jsx
@@ -29,11 +29,13 @@ const ColorButtonComponent = props => (
             {props.color === null ? (
                 <img
                     className={styles.swatchIcon}
+                    draggable={false}
                     src={noFillIcon}
                 />
             ) : ((props.color === MIXED ? (
                 <img
                     className={styles.swatchIcon}
+                    draggable={false}
                     src={mixedFillIcon}
                 />
             ) : null))}

--- a/src/components/color-picker/color-picker.jsx
+++ b/src/components/color-picker/color-picker.jsx
@@ -114,7 +114,10 @@ class ColorPickerComponent extends React.Component {
                             })}
                             onClick={this.props.onTransparent}
                         >
-                            <img src={noFillIcon} />
+                            <img
+                                draggable={false}
+                                src={noFillIcon}
+                            />
                         </div>
                     </div>
                     <div className={styles.swatches}>
@@ -125,7 +128,10 @@ class ColorPickerComponent extends React.Component {
                             })}
                             onClick={this.props.onActivateEyeDropper}
                         >
-                            <img src={eyeDropperIcon} />
+                            <img
+                                draggable={false}
+                                src={eyeDropperIcon}
+                            />
                         </div>
                     </div>
                 </div>

--- a/src/components/dropdown/dropdown.jsx
+++ b/src/components/dropdown/dropdown.jsx
@@ -50,6 +50,7 @@ class Dropdown extends React.Component {
                         className={classNames(styles.dropdownIcon, {
                             [styles.modCaretUp]: this.state.isOpen
                         })}
+                        draggable={false}
                         src={dropdownIcon}
                     />
                 </div>

--- a/src/components/labeled-icon-button/labeled-icon-button.jsx
+++ b/src/components/labeled-icon-button/labeled-icon-button.jsx
@@ -26,6 +26,7 @@ const LabeledIconButton = ({
         <img
             alt={imgAlt}
             className={styles.editFieldIcon}
+            draggable={false}
             src={imgSrc}
         />
         <span className={styles.editFieldTitle}>{title}</span>

--- a/src/components/mode-tools/mode-tools.jsx
+++ b/src/components/mode-tools/mode-tools.jsx
@@ -80,6 +80,7 @@ const ModeToolsComponent = props => {
                     <img
                         alt={props.intl.formatMessage(messages.brushSize)}
                         className={styles.modeToolsIcon}
+                        draggable={false}
                         src={brushIcon}
                     />
                 </div>
@@ -101,6 +102,7 @@ const ModeToolsComponent = props => {
                     <img
                         alt={props.intl.formatMessage(messages.eraserSize)}
                         className={styles.modeToolsIcon}
+                        draggable={false}
                         src={eraserIcon}
                     />
                 </div>

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -160,6 +160,7 @@ const PaintEditorComponent = props => {
                                     <img
                                         alt={props.intl.formatMessage(messages.undo)}
                                         className={styles.buttonGroupButtonIcon}
+                                        draggable={false}
                                         src={undoIcon}
                                     />
                                 </Button>
@@ -178,6 +179,7 @@ const PaintEditorComponent = props => {
                                     <img
                                         alt={props.intl.formatMessage(messages.redo)}
                                         className={styles.buttonGroupButtonIcon}
+                                        draggable={false}
                                         src={redoIcon}
                                     />
                                 </Button>
@@ -258,6 +260,7 @@ const PaintEditorComponent = props => {
                                             >
                                                 <img
                                                     className={styles.menuItemIcon}
+                                                    draggable={false}
                                                     src={sendFrontIcon}
                                                 />
                                                 <span>{props.intl.formatMessage(messages.front)}</span>
@@ -271,6 +274,7 @@ const PaintEditorComponent = props => {
                                             >
                                                 <img
                                                     className={styles.menuItemIcon}
+                                                    draggable={false}
                                                     src={sendBackIcon}
                                                 />
                                                 <span>{props.intl.formatMessage(messages.back)}</span>
@@ -283,6 +287,7 @@ const PaintEditorComponent = props => {
                                             >
                                                 <img
                                                     className={styles.menuItemIcon}
+                                                    draggable={false}
                                                     src={rotationPointIcon}
                                                 />
                                                 <span>{'Rotation Point'}</span>
@@ -398,6 +403,7 @@ const PaintEditorComponent = props => {
                             <div className={styles.bitmapButton}>
                                 <img
                                     className={styles.bitmapButtonIcon}
+                                    draggable={false}
                                     src={bitmapIcon}
                                 />
                                 <span>
@@ -415,6 +421,7 @@ const PaintEditorComponent = props => {
                                     <img
                                         alt="Zoom Out"
                                         className={styles.buttonGroupButtonIcon}
+                                        draggable={false}
                                         src={zoomOutIcon}
                                     />
                                 </Button>
@@ -425,6 +432,7 @@ const PaintEditorComponent = props => {
                                     <img
                                         alt="Zoom Reset"
                                         className={styles.buttonGroupButtonIcon}
+                                        draggable={false}
                                         src={zoomResetIcon}
                                     />
                                 </Button>
@@ -435,6 +443,7 @@ const PaintEditorComponent = props => {
                                     <img
                                         alt="Zoom In"
                                         className={styles.buttonGroupButtonIcon}
+                                        draggable={false}
                                         src={zoomInIcon}
                                     />
                                 </Button>

--- a/src/components/tool-select-base/tool-select-base.jsx
+++ b/src/components/tool-select-base/tool-select-base.jsx
@@ -24,6 +24,7 @@ const ToolSelectComponent = props => (
                 id: props.imgDescriptor.id
             })}
             className={styles.toolSelectIcon}
+            draggable={false}
             src={props.imgSrc}
         />
     </Button>


### PR DESCRIPTION
Resolves the costume tab part of https://github.com/LLK/scratch-gui/issues/1430
Also resolves https://github.com/LLK/scratch-gui/issues/1407

When using images as clickable elements (within buttons or alone) you
need to mark them as not draggable. They are draggable by default and
starting a drag prevents the onClick from being handled, messing up the
clickable behavior.

![no-drag-images-paint](https://user-images.githubusercontent.com/654102/36032925-81e30c42-0d7d-11e8-92cd-54c10691f84e.gif)
