### PR TITLE
Restrict exported SVG to content bounds

### DIFF
--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -75,6 +75,7 @@ class PaintEditor extends React.Component {
         this.props.onUpdateSvg(
             paper.project.exportSVG({
                 asString: true,
+                bounds: 'content',
                 matrix: new paper.Matrix().translate(-bounds.x, -bounds.y)
             }),
             paper.project.view.center.x - bounds.x,


### PR DESCRIPTION
Previously we were exporting empty space to the right and bottom of the artwork, which was reflected in sprite thumbnails as a tiny version of the sprite.

> `options.bounds`: `String`⟋`Rectangle` — the bounds of the area to export, either as a string (`‘view’`, `‘content’`), or a `Rectangle` object: `'view'` uses the view bounds, `'content'` uses the stroke bounds of all content — default: `‘view’`

/ht @fsih 

Resolves https://github.com/LLK/scratch-gui/issues/1471