### PR TITLE
Remove all view.draw and view.update

### DIFF
--- a/src/containers/line-mode.jsx
+++ b/src/containers/line-mode.jsx
@@ -112,7 +112,6 @@ class LineMode extends React.Component {
 
             this.path.add(event.point);
             this.path.add(event.point); // Add second point, which is what will move when dragged
-            paper.view.draw();
         }
     }
     drawHitPoint (hitResult) {

--- a/src/containers/mode-tools.jsx
+++ b/src/containers/mode-tools.jsx
@@ -194,7 +194,6 @@ class ModeTools extends React.Component {
             }
             this.props.incrementPasteOffset();
             this.props.setSelectedItems();
-            paper.project.view.update();
             this.props.onUpdateSvg();
         }
     }

--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -90,7 +90,6 @@ class PaintEditor extends React.Component {
         // Restore old zoom
         paper.project.view.zoom = oldZoom;
         paper.project.view.center = oldCenter;
-        paper.project.view.update();
     }
     handleUndo () {
         performUndo(this.props.undoState, this.props.onUndo, this.props.setSelectedItems, this.handleUpdateSvg);

--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -62,7 +62,6 @@ class PaperCanvas extends React.Component {
             this.importSvg(newProps.svg, newProps.rotationCenterX, newProps.rotationCenterY);
             paper.project.view.zoom = oldZoom;
             paper.project.view.center = oldCenter;
-            paper.project.view.update();
         } else {
             performSnapshot(this.props.undoSnapshot);
         }
@@ -161,7 +160,6 @@ class PaperCanvas extends React.Component {
                 }
 
                 performSnapshot(paperCanvas.props.undoSnapshot);
-                paper.project.view.update();
             }
         });
     }

--- a/src/containers/selection-hoc.jsx
+++ b/src/containers/selection-hoc.jsx
@@ -13,11 +13,6 @@ const SelectionHOC = function (WrappedComponent) {
                 'removeItemById'
             ]);
         }
-        componentDidMount () {
-            if (this.props.hoveredItemId) {
-                paper.view.update();
-            }
-        }
         componentDidUpdate (prevProps) {
             // Hovered item has changed
             if ((this.props.hoveredItemId && this.props.hoveredItemId !== prevProps.hoveredItemId) ||

--- a/src/helper/blob-tools/blob.js
+++ b/src/helper/blob-tools/blob.js
@@ -107,7 +107,6 @@ class Blobbiness {
             }
             blob.cursorPreview.bringToFront();
             blob.cursorPreview.position = event.point;
-            paper.view.draw();
         };
 
         this.tool.onMouseDrag = function (event) {
@@ -123,7 +122,6 @@ class Blobbiness {
 
             blob.cursorPreview.bringToFront();
             blob.cursorPreview.position = event.point;
-            paper.view.draw();
         };
 
         this.tool.onMouseUp = function (event) {

--- a/src/helper/selection.js
+++ b/src/helper/selection.js
@@ -203,7 +203,6 @@ const _deleteItemSelection = function (items, onUpdateSvg) {
     for (let i = 0; i < items.length; i++) {
         items[i].remove();
     }
-    paper.project.view.update();
     onUpdateSvg();
     return true;
 };
@@ -229,7 +228,6 @@ const _removeSelectedSegments = function (items, onUpdateSvg) {
         removedSegments = true;
     }
     if (removedSegments) {
-        paper.project.view.update();
         onUpdateSvg();
     }
     return removedSegments;

--- a/src/helper/undo.js
+++ b/src/helper/undo.js
@@ -19,7 +19,6 @@ const _restore = function (entry, setSelectedItems, onUpdateSvg) {
         }
     }
     paper.project.importJSON(entry.json);
-    paper.view.update();
 
     setSelectedItems();
     onUpdateSvg(true /* skipSnapshot */);


### PR DESCRIPTION
View.draw and view.update can slow performance when called too often, and we seem to call it too often. In fact, I can't tell that anything changes at all when I take them all out. So let's try taking them all out.

This work is related to https://github.com/LLK/scratch-paint/issues/23