### PR TITLE
Make sure to clear the cursor preview when saving undo state

### DIFF
--- a/src/helper/blob-tools/blob.js
+++ b/src/helper/blob-tools/blob.js
@@ -127,7 +127,6 @@ class Blobbiness {
         };
 
         this.tool.onMouseUp = function (event) {
-            blob.resizeCursorIfNeeded(event.point);
             if (event.event.button > 0 || !this.active) return; // only first mouse button
             
             let lastPath;
@@ -145,11 +144,9 @@ class Blobbiness {
                 blob.mergeBrush(lastPath);
             }
 
-            blob.cursorPreview.visible = false;
+            blob.cursorPreview.remove();
+            blob.cursorPreview = null;
             blob.onUpdateSvg();
-            blob.cursorPreview.visible = true;
-            blob.cursorPreview.bringToFront();
-            blob.cursorPreview.position = event.point;
 
             // Reset
             blob.brush = null;

--- a/src/helper/blob-tools/blob.js
+++ b/src/helper/blob-tools/blob.js
@@ -431,8 +431,10 @@ class Blobbiness {
     }
 
     deactivateTool () {
-        this.cursorPreview.remove();
-        this.cursorPreview = null;
+        if (this.cursorPreview) {
+            this.cursorPreview.remove();
+            this.cursorPreview = null;
+        }
         this.tool.remove();
         this.tool = null;
     }


### PR DESCRIPTION
Sometimes the cursor preview can reappear when undoing. Removing the cursor preview from the snapshot entirely should fix the issue.