### PR TITLE
Move the SVG in the playground back to the center of the editor

### DIFF
--- a/src/playground/playground.jsx
+++ b/src/playground/playground.jsx
@@ -32,8 +32,8 @@ class Playground extends React.Component {
         ]);
         this.state = {
             name: 'meow',
-            rotationCenterX: 0,
-            rotationCenterY: 0,
+            rotationCenterX: 20,
+            rotationCenterY: 400,
             svg: svgString
         };
     }


### PR DESCRIPTION
It became offscreen when the definition of rotation center changed.

Before
![image](https://user-images.githubusercontent.com/2855464/37433330-da930344-27b1-11e8-928f-7cd37d7d9f5f.png)

After
![image](https://user-images.githubusercontent.com/2855464/37433339-e1db4558-27b1-11e8-864d-1b21f834b6c6.png)
