### PR TITLE
Reduce the overlap to .1

### DIFF
--- a/src/helper/math.js
+++ b/src/helper/math.js
@@ -82,17 +82,17 @@ const sortItemsByZIndex = function (a, b) {
     return null;
 };
 
-// Expand the size of the path by approx one pixel all around
-const expandByOne = function (path) {
+// Expand the size of the path by amount all around
+const expandBy = function (path, amount) {
     const center = path.position;
     let pathArea = path.area;
     for (const seg of path.segments) {
-        const halfNorm = seg.point.subtract(center)
+        const delta = seg.point.subtract(center)
             .normalize()
-            .divide(2);
-        seg.point = seg.point.add(halfNorm);
+            .multiply(amount);
+        seg.point = seg.point.add(delta);
         // If that made the path area smaller, go the other way.
-        if (path.area < pathArea) seg.point = seg.point.subtract(halfNorm.multiply(2));
+        if (path.area < pathArea) seg.point = seg.point.subtract(delta.multiply(2));
         pathArea = path.area;
     }
 };
@@ -112,7 +112,7 @@ export {
     HANDLE_RATIO,
     checkPointsClose,
     ensureClockwise,
-    expandByOne,
+    expandBy,
     getRandomInt,
     getRandomBoolean,
     snapDeltaToAngle,

--- a/src/helper/tools/fill-tool.js
+++ b/src/helper/tools/fill-tool.js
@@ -104,7 +104,7 @@ class FillTool extends paper.Tool {
                 this.addedFillItem.data.origItem = hitItem;
                 // This usually fixes it so there isn't a teeny tiny gap in between the fill and the outline
                 // when filling in a hole
-                expandBy(this.addedFillItem, .25);
+                expandBy(this.addedFillItem, .1);
                 this.addedFillItem.insertAbove(hitItem.parent);
             } else if (this.fillItem.parent instanceof paper.CompoundPath) {
                 this.fillItemOrigColor = hitItem.parent.fillColor;

--- a/src/helper/tools/fill-tool.js
+++ b/src/helper/tools/fill-tool.js
@@ -1,6 +1,6 @@
 import paper from '@scratch/paper';
 import {getHoveredItem} from '../hover';
-import {expandByOne} from '../math';
+import {expandBy} from '../math';
 
 class FillTool extends paper.Tool {
     static get TOLERANCE () {
@@ -104,7 +104,7 @@ class FillTool extends paper.Tool {
                 this.addedFillItem.data.origItem = hitItem;
                 // This usually fixes it so there isn't a teeny tiny gap in between the fill and the outline
                 // when filling in a hole
-                expandByOne(this.addedFillItem);
+                expandBy(this.addedFillItem, .5);
                 this.addedFillItem.insertAbove(hitItem.parent);
             } else if (this.fillItem.parent instanceof paper.CompoundPath) {
                 this.fillItemOrigColor = hitItem.parent.fillColor;

--- a/src/helper/tools/fill-tool.js
+++ b/src/helper/tools/fill-tool.js
@@ -104,7 +104,7 @@ class FillTool extends paper.Tool {
                 this.addedFillItem.data.origItem = hitItem;
                 // This usually fixes it so there isn't a teeny tiny gap in between the fill and the outline
                 // when filling in a hole
-                expandBy(this.addedFillItem, .5);
+                expandBy(this.addedFillItem, .25);
                 this.addedFillItem.insertAbove(hitItem.parent);
             } else if (this.fillItem.parent instanceof paper.CompoundPath) {
                 this.fillItemOrigColor = hitItem.parent.fillColor;


### PR DESCRIPTION
When you fill in a hole, the fill actually is made a tiny bit bigger than the hole, because otherwise you sometimes get tiny white gaps between the fill and the outline.

The goal of the overlap is
1. Reduce the amount of gaps visible between the fill and the outline
2. Don't increase the overlap so much that it's obviously overlapping

(note that the expand algorithm is pretty naive and won't be perfect if you draw a crazy spiky outline, it's just supposed to help with most cases)

In playtesting @carljbowman found that the overlap is too obvious when using width 1 brush strokes and filling them in. The overlap used to be .5, and this reduces it to .1 canvas units.