### PR TITLE
Unfocus text fields when canvas clicked and don't take keystrokes in canvas when text fields are focused

### DIFF
--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -50,6 +50,10 @@ class PaintEditor extends React.Component {
     }
     componentDidMount () {
         document.addEventListener('keydown', this.props.onKeyPress);
+        // document listeners used to detect if a mouse is down outside of the
+        // canvas, and should therefore stop the eye dropper
+        document.addEventListener('mousedown', this.onMouseDown);
+        document.addEventListener('touchstart', this.onMouseDown);
     }
     componentDidUpdate (prevProps) {
         if (this.props.isEyeDropping && !prevProps.isEyeDropping) {
@@ -61,6 +65,8 @@ class PaintEditor extends React.Component {
     componentWillUnmount () {
         document.removeEventListener('keydown', this.props.onKeyPress);
         this.stopEyeDroppingLoop();
+        document.removeEventListener('mousedown', this.onMouseDown);
+        document.removeEventListener('touchstart', this.onMouseDown);
     }
     handleUpdateSvg (skipSnapshot) {
         // Store the zoom/pan and restore it after snapshotting
@@ -135,6 +141,10 @@ class PaintEditor extends React.Component {
         this.canvas = canvas;
     }
     onMouseDown () {
+        if (document.activeElement instanceof HTMLInputElement) {
+            document.activeElement.blur();
+        }
+
         if (this.props.isEyeDropping) {
             const colorString = this.eyeDropper.colorString;
             const callback = this.props.changeColorToEyeDropper;
@@ -164,11 +174,6 @@ class PaintEditor extends React.Component {
         this.eyeDropper.pickX = -1;
         this.eyeDropper.pickY = -1;
         this.eyeDropper.activate();
-
-        // document listeners used to detect if a mouse is down outside of the
-        // canvas, and should therefore stop the eye dropper
-        document.addEventListener('mousedown', this.onMouseDown);
-        document.addEventListener('touchstart', this.onMouseDown);
         
         this.intervalId = setInterval(() => {
             const colorInfo = this.eyeDropper.getColorInfo(
@@ -190,8 +195,6 @@ class PaintEditor extends React.Component {
     }
     stopEyeDroppingLoop () {
         clearInterval(this.intervalId);
-        document.removeEventListener('mousedown', this.onMouseDown);
-        document.removeEventListener('touchstart', this.onMouseDown);
     }
     render () {
         return (

--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -140,8 +140,9 @@ class PaintEditor extends React.Component {
         this.setState({canvas: canvas});
         this.canvas = canvas;
     }
-    onMouseDown () {
-        if (document.activeElement instanceof HTMLInputElement) {
+    onMouseDown (event) {
+        if (event.target === paper.view.element &&
+                document.activeElement instanceof HTMLInputElement) {
             document.activeElement.blur();
         }
 

--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -232,6 +232,11 @@ class ReshapeTool extends paper.Tool {
         this.active = false;
     }
     handleKeyDown (event) {
+        if (event.event.target instanceof HTMLInputElement) {
+            // Ignore nudge if a text input field is focused
+            return;
+        }
+
         const nudgeAmount = 1 / paper.view.zoom;
         const selected = getSelectedLeafItems();
         if (selected.length === 0) return;


### PR DESCRIPTION
Fix some issues where you can edit text and the paint editor at the same time.