### PR TITLE
Line connect guide size remains same when zooming #179

### DIFF
--- a/src/helper/guides.js
+++ b/src/helper/guides.js
@@ -104,7 +104,8 @@ const removeHitPoint = function () {
 const drawHitPoint = function (point) {
     removeHitPoint();
     if (point) {
-        const hitPoint = paper.Path.Circle(point, 4 /* radius */);
+        const hitPoint = paper.Path.Circle(point, 4 / paper.view.zoom /* radius */);
+        hitPoint.strokeWidth = 1 / paper.view.zoom;
         hitPoint.strokeColor = GUIDE_BLUE;
         hitPoint.fillColor = new paper.Color(1, 1, 1, 0.5);
         hitPoint.parent = getGuideLayer();


### PR DESCRIPTION
The radius of the circle is now divided by paper.view.zoom, and the strokeWidth also. (Fixes #179)