### PR TITLE
Reduce target when fill hole with same color #301

### DIFF
--- a/src/helper/group.js
+++ b/src/helper/group.js
@@ -49,7 +49,7 @@ const _ungroupLoop = function (group, recursive, setSelectedItems) {
     // iterate over group children recursively
     for (let i = 0; i < group.children.length; i++) {
         let groupChild = group.children[i];
-        if (groupChild.hasChildren()) {
+        if (groupChild instanceof paper.Group && groupChild.hasChildren()) {
             // recursion (groups can contain groups, ie. from SVG import)
             if (recursive) {
                 _ungroupLoop(groupChild, recursive, setSelectedItems);

--- a/src/helper/tools/fill-tool.js
+++ b/src/helper/tools/fill-tool.js
@@ -121,8 +121,11 @@ class FillTool extends paper.Tool {
                     this.addedFillItem.fillColor.type !== 'gradient' &&
                     this.fillItem.parent.fillColor.toCSS() === this.addedFillItem.fillColor.toCSS()) {
                 this.addedFillItem.remove();
-                this.addedFillItem = null;
+                this.addedFillItem = null;     
+                var parent = this.fillItem.parent;
                 this.fillItem.remove();
+                parent = parent.reduce();
+                parent.fillColor = this.fillColor;
             } else if (this.addedFillItem) {
                 // Fill in a hole.
                 this.addedFillItem.data.noHover = false;

--- a/src/helper/tools/fill-tool.js
+++ b/src/helper/tools/fill-tool.js
@@ -121,8 +121,8 @@ class FillTool extends paper.Tool {
                     this.addedFillItem.fillColor.type !== 'gradient' &&
                     this.fillItem.parent.fillColor.toCSS() === this.addedFillItem.fillColor.toCSS()) {
                 this.addedFillItem.remove();
-                this.addedFillItem = null;     
-                var parent = this.fillItem.parent;
+                this.addedFillItem = null;
+                let parent = this.fillItem.parent;
                 this.fillItem.remove();
                 parent = parent.reduce();
                 parent.fillColor = this.fillColor;


### PR DESCRIPTION
Fixes #301

When removing a hole, the parent should be reduced before fillColor is set