### PR TITLE
Fix editorconfig indentation rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,8 +4,13 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
-indent_size = 4
 trim_trailing_whitespace = true
 
-[*.{js,html}]
 indent_style = space
+indent_size = 4
+
+[*.yml]
+ident_style = tab
+
+[*.json]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,8 +9,5 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.yml]
-ident_style = tab
-
-[*.json]
+[*.{yml,json}]
 indent_size = 2

--- a/src/playground/index.ejs
+++ b/src/playground/index.ejs
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title><%= htmlWebpackPlugin.options.title %></title>
-  </head>
-  <body>
-  </body>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title><%= htmlWebpackPlugin.options.title %></title>
+    </head>
+    <body>
+    </body>
 </html>


### PR DESCRIPTION
Rules before:

* 4-wide tabs everywhere, except
* .js and .html files, using 4 spaces **(note this project also uses .ejs & .jsx files which are not covered by this!)**

Changed in this PR to:

* 4 spaces everywhere (ie. including .jsx and .ejs files), except
* .yml files, using 4-wide tabs
* .json files (eg. package.json), using 2 spaces (may want to change package.json to use 4sp?)

Also fixed index.ejs to use 4 spaces instead of two.