### PR TITLE
Disable keyboard shortcuts because they interfere with text tool

### DIFF
--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -55,10 +55,12 @@ class PaintEditor extends React.Component {
         };
     }
     componentDidMount () {
-        document.addEventListener('keydown', event => {
+        document.addEventListener('keydown', _event => {
             // Don't activate keyboard shortcuts during text editing
             if (!this.props.textEditing) {
-                this.props.onKeyPress(event);
+                // @todo disabling keyboard shortcuts because there is a bug
+                // that is interfering with text editing.
+                // this.props.onKeyPress(_event);
             }
         });
         // document listeners used to detect if a mouse is down outside of the


### PR DESCRIPTION
The single-letter keyboard shortcuts are interfering with using the text tool for some reason. In order to get this out today, I'm going to disable them, but @fsih let's talk about this when you get back.