### PR TITLE
Bring back eraser after snapshot

### DIFF
--- a/src/helper/blob-tools/blob.js
+++ b/src/helper/blob-tools/blob.js
@@ -141,9 +141,10 @@ class Blobbiness {
                 blob.mergeBrush(lastPath);
             }
 
+            // Remove cursor preview during snapshot, then bring it back
             blob.cursorPreview.remove();
-            blob.cursorPreview = null;
             blob.onUpdateSvg();
+            blob.cursorPreview.parent = getGuideLayer();
 
             // Reset
             blob.brush = null;


### PR DESCRIPTION
### Resolves
https://github.com/LLK/scratch-paint/issues/322 Eraser pointer disappears if you click with the eraser tool

### Proposed Changes
Bring back the eraser cursor preview on mouse up.