### PR TITLE
Issue/332 Rotate-tool fix

### DIFF
--- a/src/helper/selection-tools/rotate-tool.js
+++ b/src/helper/selection-tools/rotate-tool.js
@@ -27,7 +27,7 @@ class RotateTool {
                 this.rotItems.push(item);
             }
         }
-        this.prevRot = 90;        
+        this.prevRot = 90;
     }
     onMouseDrag (event) {
         let rotAngle = (event.point.subtract(this.rotGroupPivot)).angle;

--- a/src/helper/selection-tools/rotate-tool.js
+++ b/src/helper/selection-tools/rotate-tool.js
@@ -31,20 +31,21 @@ class RotateTool {
     }
     onMouseDrag (event) {
         let rotAngle = (event.point.subtract(this.rotGroupPivot)).angle;
-        
+        if (event.modifiers.shift) {
+            rotAngle = Math.round(rotAngle / 45) * 45;
+        }
+
         for (let i = 0; i < this.rotItems.length; i++) {
             const item = this.rotItems[i];
             
             if (!item.data.origRot) {
                 item.data.origRot = item.rotation;
             }
-            
-            if (event.modifiers.shift) {
-                rotAngle = Math.round(rotAngle / 45) * 45;
-            }
+
             item.rotate(rotAngle - this.prevRot, this.rotGroupPivot);
-            this.prevRot = rotAngle;
         }
+
+        this.prevRot = rotAngle;
     }
     onMouseUp (event) {
         if (event.event.button > 0) return; // only first mouse button

--- a/src/helper/selection-tools/rotate-tool.js
+++ b/src/helper/selection-tools/rotate-tool.js
@@ -44,12 +44,8 @@ class RotateTool {
             
             if (event.modifiers.shift) {
                 rotAngle = Math.round(rotAngle / 45) * 45;
-                item.applyMatrix = false;
-                item.pivot = this.rotGroupPivot;
-                item.rotation = rotAngle;
-            } else {
-                item.rotate(rotAngle - this.prevRot[i], this.rotGroupPivot);
             }
+            item.rotate(rotAngle - this.prevRot[i], this.rotGroupPivot);
             this.prevRot[i] = rotAngle;
         }
     }

--- a/src/helper/selection-tools/rotate-tool.js
+++ b/src/helper/selection-tools/rotate-tool.js
@@ -10,7 +10,7 @@ class RotateTool {
     constructor (onUpdateSvg) {
         this.rotItems = [];
         this.rotGroupPivot = null;
-        this.prevRot = [];
+        this.prevRot = 90;
         this.onUpdateSvg = onUpdateSvg;
     }
 
@@ -27,10 +27,7 @@ class RotateTool {
                 this.rotItems.push(item);
             }
         }
-        
-        for (let i = 0; i < this.rotItems.length; i++) {
-            this.prevRot[i] = 90;
-        }
+        this.prevRot = 90;        
     }
     onMouseDrag (event) {
         let rotAngle = (event.point.subtract(this.rotGroupPivot)).angle;
@@ -45,8 +42,8 @@ class RotateTool {
             if (event.modifiers.shift) {
                 rotAngle = Math.round(rotAngle / 45) * 45;
             }
-            item.rotate(rotAngle - this.prevRot[i], this.rotGroupPivot);
-            this.prevRot[i] = rotAngle;
+            item.rotate(rotAngle - this.prevRot, this.rotGroupPivot);
+            this.prevRot = rotAngle;
         }
     }
     onMouseUp (event) {
@@ -57,7 +54,7 @@ class RotateTool {
         
         this.rotItems.length = 0;
         this.rotGroupPivot = null;
-        this.prevRot = [];
+        this.prevRot = 90;
 
         this.onUpdateSvg();
     }


### PR DESCRIPTION
### Resolves

Fixes issue #332 concerning text rotation holding shift. Somehow for text items the old code did not work while for other items it did.

### Proposed Changes

The code for shift handling is now simplified and does what it is supposed to do.

Also I changed prevRot to not be an array. It was not needed as an array a number was enough.

### Reason for Changes

Holding shift while rotating seemed to change pivot point while rotating. It was a bug.

### Test Coverage

I did not add tests, but tested rotating several different objects in Chrome.

PS. Sorry for the messy merge PR with the merge commit in it. I know it is possible to make it cleaner and in one commit but I need some advice on how to do it. I probably need to make a new clean fork once all PRs are handled.