### PR TITLE
Add ability to fill transparent text

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-dom": "^16"
   },
   "devDependencies": {
-    "@scratch/paper": "0.11.20180329192534",
+    "@scratch/paper": "0.11.20180411183636",
     "autoprefixer": "8.1.0",
     "babel-cli": "6.26.0",
     "babel-core": "^6.23.1",

--- a/src/helper/tools/fill-tool.js
+++ b/src/helper/tools/fill-tool.js
@@ -44,8 +44,13 @@ class FillTool extends paper.Tool {
             fill: true,
             guide: false,
             match: function (hitResult) {
-                return (hitResult.item instanceof paper.Path || hitResult.item instanceof paper.PointText) &&
-                    (hitResult.item.hasFill() || hitResult.item.closed || isAlmostClosedPath(hitResult.item));
+                if (hitResult.item instanceof paper.Path &&
+                    (hitResult.item.hasFill() || hitResult.item.closed || isAlmostClosedPath(hitResult.item))) {
+                    return true;
+                }
+                if (hitResult.item instanceof paper.PointText) {
+                    return true;
+                }
             },
             hitUnfilledPaths: true,
             tolerance: FillTool.TOLERANCE / paper.view.zoom


### PR DESCRIPTION
### Resolves
Along with https://github.com/LLK/paper.js/pull/9 , this change allows transparent text to be filled with the fill tool. Before, transparent text would not be detected by the fill tool at all.

### Proposed Changes

For point text, don't require hasFill()

### Reason for Changes

The fill tool should be able to fill in things you've made transparent, including text