### PR TITLE
Make sure to remove the bounding box when no items are selected

### DIFF
--- a/src/helper/selection-tools/bounding-box-tool.js
+++ b/src/helper/selection-tools/bounding-box-tool.js
@@ -51,10 +51,10 @@ class BoundingBoxTool {
 
     /**
      * Should be called if the selection changes to update the bounds of the bounding box.
-     * @param {Array<paper.Item>} selectedItems Array of selected items.
+     * @param {?Array<paper.Item>} selectedItems Array of selected items.
      */
     onSelectionChanged (selectedItems) {
-        if (selectedItems) {
+        if (selectedItems && selectedItems.length) {
             this.setSelectionBounds();
         } else {
             this.removeBoundsPath();


### PR DESCRIPTION
No bounding box should be shown when no items are selected.