### PR TITLE
Escape end text edit mode #366

### DIFF
--- a/src/helper/tools/text-tool.js
+++ b/src/helper/tools/text-tool.js
@@ -239,7 +239,9 @@ class TextTool extends paper.Tool {
             // Ignore nudge if a text input field is focused
             return;
         }
-        
+        if (this.mode === TextTool.TEXT_EDIT_MODE && event.key === 'escape') {
+            this.endTextEdit();
+        }        
         if (this.mode === TextTool.SELECT_MODE) {
             this.nudgeTool.onKeyDown(event);
         }

--- a/src/helper/tools/text-tool.js
+++ b/src/helper/tools/text-tool.js
@@ -241,7 +241,7 @@ class TextTool extends paper.Tool {
         }
         if (this.mode === TextTool.TEXT_EDIT_MODE && event.key === 'escape') {
             this.endTextEdit();
-        }        
+        }
         if (this.mode === TextTool.SELECT_MODE) {
             this.nudgeTool.onKeyDown(event);
         }


### PR DESCRIPTION
### Resolves

Fixes issue #366

### Proposed Changes

Handle escape key while editing in onKeyDown calling endTextEdit

Discussion: 

1. This probably goes for all tools. Maybe we should look for a generic escape key handling?
2. Is saw that some code is never triggered. 

`if (event.event.target instanceof HTMLInputElement) {`

### Reason for Changes

Issue #366 

### Test Coverage

Tested in chrome