### PR TITLE
Remove ungroup on import

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -10,7 +10,6 @@ import log from '../log/log';
 import {trim} from '../helper/bitmap';
 import {performSnapshot} from '../helper/undo';
 import {undoSnapshot, clearUndoState} from '../reducers/undo';
-import {isGroup, ungroupItems} from '../helper/group';
 import {clearRaster, getRaster, setupLayers, hideGuideLayers, showGuideLayers} from '../helper/layer';
 import {deleteSelection, getSelectedLeafItems} from '../helper/selection';
 import {clearSelectedItems, setSelectedItems} from '../reducers/selected-items';
@@ -232,9 +231,6 @@ class PaperCanvas extends React.Component {
                     // Center
                     item.translate(paper.project.view.center
                         .subtract(itemWidth / 2, itemHeight / 2));
-                }
-                if (isGroup(item)) {
-                    ungroupItems([item]);
                 }
 
                 performSnapshot(paperCanvas.props.undoSnapshot, paperCanvas.props.format);


### PR DESCRIPTION
### Resolves
https://github.com/LLK/scratch-paint/issues/258

### Proposed Changes
Don't ungroup sprites when importing