### PR TITLE
Reconfigure paint transifex config

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[experimental-scratch.scratch-paint]
+[scratch-editor.paint-editor]
 file_filter = translations/<lang>.json
 source_file = translations/en.json
 source_lang = en


### PR DESCRIPTION
Switch config file over to public ‘scratch-editor’ project on transifex.

This allows the paint strings to be translated.