### PR TITLE
Fix button text wrapping in Edge

### DIFF
--- a/src/components/paint-editor/paint-editor.css
+++ b/src/components/paint-editor/paint-editor.css
@@ -230,3 +230,7 @@ $border-radius: 0.25rem;
     -webkit-text-fill-color: transparent;
     text-fill-color: transparent;
 }
+
+.button-text {
+    width: 100%; /* Fixes button text wrapping in Edge */
+}

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -468,7 +468,7 @@ const PaintEditorComponent = props => {
                                     draggable={false}
                                     src={bitmapIcon}
                                 />
-                                <span>
+                                <span className={styles.buttonText}>
                                     {props.intl.formatMessage(messages.bitmap)}
                                 </span>
                             </Button> :
@@ -482,7 +482,7 @@ const PaintEditorComponent = props => {
                                         draggable={false}
                                         src={bitmapIcon}
                                     />
-                                    <span>
+                                    <span className={styles.buttonText}>
                                         {props.intl.formatMessage(messages.vector)}
                                     </span>
                                 </Button> : null


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes an issue where the button text was wrapping because of flexbox inconsistencies between edge and other browsers. 

### Proposed Changes

_Describe what this Pull Request does_

Add a width: 100% to the button text to get it to fill the space instead of wrapping.

### Reason for Changes

_Explain why these changes should be made_

![image](https://user-images.githubusercontent.com/654102/39543530-7bb81b46-4e19-11e8-86a9-e96e11fe761e.png)


![image](https://user-images.githubusercontent.com/654102/39543534-7d811388-4e19-11e8-8dd4-856484756b8e.png)
