### PR TITLE
Fix image conversion in Firefox and add fallback

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -107,7 +107,18 @@ class PaperCanvas extends React.Component {
             paper.project.activeLayer.removeChildren();
             this.props.onUpdateImage();
         };
-        img.src = `data:image/svg+xml;charset=utf-8,${svgString}`;
+        img.onerror = () => {
+            // Fallback if browser does not support SVG data URIs in images.
+            // The problem with rasterize is that it will anti-alias.
+            const raster = paper.project.activeLayer.rasterize(72, false /* insert */);
+            raster.onLoad = () => {
+                getRaster().drawImage(raster.canvas, raster.bounds.topLeft);
+                paper.project.activeLayer.removeChildren();
+                this.props.onUpdateImage();
+            };
+        };
+        // Hash tags will break image loading without being encoded first
+        img.src = `data:image/svg+xml;utf8,${encodeURIComponent(svgString)}`;
     }
     convertToVector () {
         this.props.clearSelectedItems();


### PR DESCRIPTION
### Resolves

Fixes https://github.com/LLK/scratch-paint/issues/388
Fixes https://github.com/LLK/scratch-gui/issues/1930

### Proposed Changes

Encode svg string before passing it to an image
Also, if the image fails to load, fall back to paper's rasterize instead of leaving the vector on the screen.

### Test Coverage

Tested Firefox, Safari on Mac
Tested converting sprites with utf8 text
Testing on Windows needed to check if https://github.com/LLK/scratch-paint/issues/397 is fixed