### PR TITLE
Listen to undo state in fixedTools

### DIFF
--- a/src/components/fixed-tools/fixed-tools.jsx
+++ b/src/components/fixed-tools/fixed-tools.jsx
@@ -301,7 +301,8 @@ FixedToolsComponent.propTypes = {
 
 const mapStateToProps = state => ({
     format: state.scratchPaint.format,
-    selectedItems: state.scratchPaint.selectedItems
+    selectedItems: state.scratchPaint.selectedItems,
+    undoState: state.scratchPaint.undo
 });
 
 export default connect(


### PR DESCRIPTION
Top toolbar should listen to undo state so that undo button enabled state updates correctly