### PR TITLE
Queue initial undo snapshot

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -250,7 +250,10 @@ class PaperCanvas extends React.Component {
                         .subtract(itemWidth, itemHeight));
                 }
 
-                performSnapshot(paperCanvas.props.undoSnapshot, Formats.VECTOR_SKIP_CONVERT);
+                // Without the callback, the transforms sometimes don't finish applying before the
+                // snapshot is taken.
+                window.setTimeout(
+                    () => performSnapshot(paperCanvas.props.undoSnapshot, Formats.VECTOR_SKIP_CONVERT), 0);
             }
         });
     }


### PR DESCRIPTION
### Resolves

Fixes https://github.com/LLK/scratch-paint/issues/330

### Proposed Changes
Queue undo snapshot on initial SVG load. This allows transforms to finish applying before taking a snapshot

### Test Coverage
Tested on Windows Chrome and Firefox