### PR TITLE
Update scratch render fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "regenerator-runtime": "^0.11.1",
     "rimraf": "^2.6.1",
     "scratch-l10n": "^2.0.0",
-    "scratch-svg-renderer": "0.1.0-prerelease.20180511144653",
+    "scratch-svg-renderer": "0.1.0-prerelease.20180514170126",
     "style-loader": "^0.21.0",
     "svg-url-loader": "^2.3.2",
     "tap": "^11.1.0",

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -9,5 +9,10 @@ module.exports = {
         'import/no-commonjs': 'error',
         'import/no-amd': 'error',
         'import/no-nodejs-modules': 'error'
+    },
+    settings: {
+        react: {
+            version: '16.2' // Prevent 16.3 lifecycle method errors
+        }
     }
 };


### PR DESCRIPTION
Fixes IE11 by updating to the version of scratch-svg-renderer that builds scratch-render-fonts through babel instead of loading the source file directly. 

Also includes the linting fix that is now needed due to react 16.3, see https://github.com/LLK/scratch-gui/pull/2051