### PR TITLE
Add todo

### DIFF
--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -133,6 +133,7 @@ class PaintEditor extends React.Component {
             // Export at 0.5x
             scaleWithStrokes(paper.project.activeLayer, .5, new paper.Point());
             const bounds = paper.project.activeLayer.bounds;
+            // @todo generate view box
             this.props.onUpdateImage(
                 true /* isVector */,
                 paper.project.exportSVG({


### PR DESCRIPTION
The paint editor does not export the viewbox attribute in its svgs, which may change the view port for images, such as in https://github.com/LLK/scratch-paint/issues/445