### PR TITLE
Ungroup layer groups generated by paper

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -12,6 +12,7 @@ import {inlineSvgFonts} from 'scratch-svg-renderer';
 import {trim} from '../helper/bitmap';
 import {performSnapshot} from '../helper/undo';
 import {undoSnapshot, clearUndoState} from '../reducers/undo';
+import {isGroup, ungroupItems} from '../helper/group';
 import {clearRaster, getRaster, setupLayers, hideGuideLayers, showGuideLayers} from '../helper/layer';
 import {deleteSelection, getSelectedLeafItems} from '../helper/selection';
 import {clearSelectedItems, setSelectedItems} from '../reducers/selected-items';
@@ -251,6 +252,9 @@ class PaperCanvas extends React.Component {
                     // Center
                     item.translate(new paper.Point(ART_BOARD_WIDTH / 2, ART_BOARD_HEIGHT / 2)
                         .subtract(itemWidth, itemHeight));
+                }
+                if (isGroup(item) && item.data.isPaintingLayer) {
+                    ungroupItems([item]);
                 }
 
                 // Without the callback, the transforms sometimes don't finish applying before the

--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -253,7 +253,7 @@ class PaperCanvas extends React.Component {
                     item.translate(new paper.Point(ART_BOARD_WIDTH / 2, ART_BOARD_HEIGHT / 2)
                         .subtract(itemWidth, itemHeight));
                 }
-                if (isGroup(item) && item.data.isPaintingLayer) {
+                if (isGroup(item) && item.data && item.data.isPaintingLayer) {
                     ungroupItems([item]);
                 }
 


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/452

### Proposed Changes
Ungroup groups created by Paper. The painting layer is becoming a group.