### PR TITLE
Safety check cursor preview

### DIFF
--- a/src/helper/bit-tools/brush-tool.js
+++ b/src/helper/bit-tools/brush-tool.js
@@ -72,7 +72,9 @@ class BrushTool extends paper.Tool {
         if (event.event.button > 0) return; // only first mouse button
         this.active = true;
         
-        this.cursorPreview.remove();
+        if (this.cursorPreview) {
+            this.cursorPreview.remove();
+        }
 
         this.draw(event.point.x, event.point.y);
         this.lastPoint = event.point;


### PR DESCRIPTION
### Resolves

Should fix https://github.com/LLK/scratch-paint/issues/408

### Proposed Changes

Check that cursor preview is not null before removing
