### PR TITLE
Fix drawing rectangle while holding shift

### DIFF
--- a/src/helper/tools/rect-tool.js
+++ b/src/helper/tools/rect-tool.js
@@ -84,14 +84,18 @@ class RectTool extends paper.Tool {
             this.rect.remove();
         }
 
+        const dimensions = event.point.subtract(event.downPoint);
         const rect = new paper.Rectangle(event.downPoint, event.point);
         if (event.modifiers.shift) {
             rect.height = rect.width;
+            dimensions.y = event.downPoint.y > event.point.y ? -Math.abs(rect.width) : Math.abs(rect.width);
         }
         this.rect = new paper.Path.Rectangle(rect);
         
         if (event.modifiers.alt) {
             this.rect.position = event.downPoint;
+        } else {
+            this.rect.position = event.downPoint.add(dimensions.multiply(.5));
         }
         
         styleShape(this.rect, this.colorState);


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/492

### Proposed Changes

Keep the corner in the same place when drawing a rectangle using shift
![rectangleshift2](https://user-images.githubusercontent.com/2855464/41070279-e4686288-69bf-11e8-9124-dedc4e1c0ad5.gif)
