### PR TITLE
Protect against drawing zero sized images, fixing Firefox crashes

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -132,8 +132,6 @@ class PaperCanvas extends React.Component {
         const trimmedRaster = trim(getRaster());
         if (trimmedRaster) {
             paper.project.activeLayer.addChild(trimmedRaster);
-        } else {
-            getRaster().remove();
         }
         clearRaster();
         this.props.onUpdateImage();

--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -104,10 +104,11 @@ class PaperCanvas extends React.Component {
         // Put anti-aliased SVG into image, and dump image back into canvas
         const img = new Image();
         img.onload = () => {
-            getRaster().drawImage(
-                img,
-                new paper.Point(Math.floor(bounds.topLeft.x), Math.floor(bounds.topLeft.y)));
-
+            if (img.width && img.height) {
+                getRaster().drawImage(
+                    img,
+                    new paper.Point(Math.floor(bounds.topLeft.x), Math.floor(bounds.topLeft.y)));
+            }
             paper.project.activeLayer.removeChildren();
             this.props.onUpdateImage();
         };
@@ -116,7 +117,9 @@ class PaperCanvas extends React.Component {
             // The problem with rasterize is that it will anti-alias.
             const raster = paper.project.activeLayer.rasterize(72, false /* insert */);
             raster.onLoad = () => {
-                getRaster().drawImage(raster.canvas, raster.bounds.topLeft);
+                if (raster.canvas.width && raster.canvas.height) {
+                    getRaster().drawImage(raster.canvas, raster.bounds.topLeft);
+                }
                 paper.project.activeLayer.removeChildren();
                 this.props.onUpdateImage();
             };
@@ -126,11 +129,11 @@ class PaperCanvas extends React.Component {
     }
     convertToVector () {
         this.props.clearSelectedItems();
-        const raster = trim(getRaster());
-        if (raster.width === 0 || raster.height === 0) {
-            raster.remove();
+        const trimmedRaster = trim(getRaster());
+        if (trimmedRaster) {
+            paper.project.activeLayer.addChild(trimmedRaster);
         } else {
-            paper.project.activeLayer.addChild(raster);
+            getRaster().remove();
         }
         clearRaster();
         this.props.onUpdateImage();

--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -142,7 +142,11 @@ const getHitBounds = function (raster) {
 };
 
 const trim = function (raster) {
-    return raster.getSubRaster(getHitBounds(raster));
+    const hitBounds = getHitBounds(raster);
+    if (hitBounds.width && hitBounds.height) {
+        return raster.getSubRaster(getHitBounds(raster));
+    }
+    return null;
 };
 
 export {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/2232

### Proposed Changes

_Describe what this Pull Request does_

Do not `drawImage` using an image or canvas of zero width/height. Firefox will throw errors, and it will cause the paint editor to crash.

### Test Coverage

_Please show how you have added tests to cover your changes_

Fixes the following using mac/firefox:

- Add empty sprite, convert to bitmap and convert back ![empty-sprite-crash](https://user-images.githubusercontent.com/654102/41100408-44b6cb74-6a2f-11e8-9f91-e991c83d635d.gif)

---

@fsih i think this should get in for the smoke test tomorrow. 