### PR TITLE
Reungroup

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -196,7 +196,13 @@ class PaperCanvas extends React.Component {
                     item.translate(new paper.Point(ART_BOARD_WIDTH / 2, ART_BOARD_HEIGHT / 2)
                         .subtract(itemWidth, itemHeight));
                 }
-                if (isGroup(item) && item.data && item.data.isPaintingLayer) {
+                if (isGroup(item)) {
+                    // Fixes an issue where we may export empty groups
+                    for (const child of item.children) {
+                        if (isGroup(child) && child.children.length === 0) {
+                            child.remove();
+                        }
+                    }
                     ungroupItems([item]);
                 }
 


### PR DESCRIPTION
Ungroup sprites by default again in the paint editor.

We have found that it's very difficult for new users to pose sprites, because they first have to understand the concept of grouping. Therefore we're going back to ungrouping sprites by default.