### PR TITLE
Fix bit brush on touch devices

### DIFF
--- a/src/components/forms/slider.css
+++ b/src/components/forms/slider.css
@@ -17,4 +17,5 @@
     background-color: white;
     border-radius: 100%;
     box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.15);
+    touch-action: none;
 }

--- a/src/helper/bit-tools/brush-tool.js
+++ b/src/helper/bit-tools/brush-tool.js
@@ -35,6 +35,9 @@ class BrushTool extends paper.Tool {
     }
     // Draw a brush mark at the given point
     draw (x, y) {
+        if (!this.tmpCanvas) {
+            this.tmpCanvas = getBrushMark(this.size, this.color);
+        }
         const roundedUpRadius = Math.ceil(this.size / 2);
         getRaster().drawImage(this.tmpCanvas, new paper.Point(~~x - roundedUpRadius, ~~y - roundedUpRadius));
     }

--- a/src/helper/bit-tools/line-tool.js
+++ b/src/helper/bit-tools/line-tool.js
@@ -38,6 +38,9 @@ class LineTool extends paper.Tool {
     }
     // Draw a brush mark at the given point
     draw (x, y) {
+        if (!this.tmpCanvas) {
+            this.tmpCanvas = getBrushMark(this.size, this.color);
+        }
         const roundedUpRadius = Math.ceil(this.size / 2);
         this.drawTarget.drawImage(this.tmpCanvas, new paper.Point(~~x - roundedUpRadius, ~~y - roundedUpRadius));
     }
@@ -72,8 +75,8 @@ class LineTool extends paper.Tool {
     handleMouseDown (event) {
         if (event.event.button > 0) return; // only first mouse button
         this.active = true;
-        
-        this.cursorPreview.remove();
+
+        if (this.cursorPreview) this.cursorPreview.remove();
 
         const tmpCanvas = document.createElement('canvas');
         tmpCanvas.width = ART_BOARD_WIDTH;


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-paint/issues/396
Fixes https://github.com/LLK/scratch-paint/issues/429
Fixes https://github.com/LLK/scratch-paint/issues/281
### Proposed Changes

_Describe what this Pull Request does_

Make sure there is a `tmpCanvas` before drawing with it. There was an implicit assumption that `mousemove` would happen before `mousedown`, which is true for devices with mice/trackpads, but not true for touch. Fix is pretty straightforward

Also fixes a few other minor touch issues, like a similar problem with the bit brush tool and an issue with the color picker sliders on touch. 

---

Tested with a chromebook and iPad