### PR TITLE
Better fix for bit brush, eraser and line tools on touch

### DIFF
--- a/src/helper/bit-tools/brush-tool.js
+++ b/src/helper/bit-tools/brush-tool.js
@@ -30,16 +30,15 @@ class BrushTool extends paper.Tool {
     }
     setColor (color) {
         this.color = color;
+        this.tmpCanvas = getBrushMark(this.size, this.color, this.isEraser);
     }
     setBrushSize (size) {
         // For performance, make sure this is an integer
         this.size = Math.max(1, ~~size);
+        this.tmpCanvas = getBrushMark(this.size, this.color, this.isEraser);
     }
     // Draw a brush mark at the given point
     draw (x, y) {
-        if (!this.tmpCanvas) {
-            this.tmpCanvas = getBrushMark(this.size, this.color);
-        }
         const roundedUpRadius = Math.ceil(this.size / 2);
         const context = getRaster().getContext('2d');
         if (this.isEraser) {

--- a/src/helper/bit-tools/line-tool.js
+++ b/src/helper/bit-tools/line-tool.js
@@ -31,16 +31,15 @@ class LineTool extends paper.Tool {
     }
     setColor (color) {
         this.color = color;
+        this.tmpCanvas = getBrushMark(this.size, this.color);
     }
     setLineSize (size) {
         // For performance, make sure this is an integer
         this.size = Math.max(1, ~~size);
+        this.tmpCanvas = getBrushMark(this.size, this.color);
     }
     // Draw a brush mark at the given point
     draw (x, y) {
-        if (!this.tmpCanvas) {
-            this.tmpCanvas = getBrushMark(this.size, this.color);
-        }
         const roundedUpRadius = Math.ceil(this.size / 2);
         this.drawTarget.drawImage(this.tmpCanvas, new paper.Point(~~x - roundedUpRadius, ~~y - roundedUpRadius));
     }


### PR DESCRIPTION
@fsih this is a slightly improved version of that touch fix for the bitmap tools, where the tmp canvas is updated when the corresponding properties that determine it are updated, rather than at draw time. This fixes the bug where you could draw with the wrong color on touch. It also fixes the problem that the fix did not correctly take into account the eraser mode, because it was added before the bitmap eraser.

I decided to do this instead of the full cursor update because this is more of the "minimal fixing change", since the other cursor update stuff is not relevant on touch.