### PR TITLE
Bit text tool

### DIFF
--- a/src/components/bit-text-mode/bit-text-mode.jsx
+++ b/src/components/bit-text-mode/bit-text-mode.jsx
@@ -1,27 +1,26 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-import {ComingSoonTooltip} from '../coming-soon/coming-soon.jsx';
 import ToolSelectComponent from '../tool-select-base/tool-select-base.jsx';
 
 import textIcon from './text.svg';
 
-const BitTextComponent = () => (
-    <ComingSoonTooltip
-        place="right"
-        tooltipId="bit-text-mode"
-    >
-        <ToolSelectComponent
-            disabled
-            imgDescriptor={{
-                defaultMessage: 'Text',
-                description: 'Label for the text tool',
-                id: 'paint.textMode.text'
-            }}
-            imgSrc={textIcon}
-            isSelected={false}
-            onMouseDown={function () {}} // eslint-disable-line react/jsx-no-bind
-        />
-    </ComingSoonTooltip>
+const BitTextComponent = props => (
+    <ToolSelectComponent
+        imgDescriptor={{
+            defaultMessage: 'Text',
+            description: 'Label for the text tool',
+            id: 'paint.textMode.text'
+        }}
+        imgSrc={textIcon}
+        isSelected={props.isSelected}
+        onMouseDown={props.onMouseDown}
+    />
 );
+
+BitTextComponent.propTypes = {
+    isSelected: PropTypes.bool.isRequired,
+    onMouseDown: PropTypes.func.isRequired
+};
 
 export default BitTextComponent;

--- a/src/components/mode-tools/mode-tools.jsx
+++ b/src/components/mode-tools/mode-tools.jsx
@@ -187,6 +187,8 @@ const ModeToolsComponent = props => {
                 </InputGroup>
             </div>
         );
+    case Modes.BIT_TEXT:
+        /* falls through */
     case Modes.TEXT:
         return (
             <div className={classNames(props.className, styles.modeTools)}>

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -10,7 +10,6 @@ import BitBrushMode from '../../containers/bit-brush-mode.jsx';
 import BitLineMode from '../../containers/bit-line-mode.jsx';
 import BitOvalMode from '../../components/bit-oval-mode/bit-oval-mode.jsx';
 import BitRectMode from '../../containers/bit-rect-mode.jsx';
-import BitTextMode from '../../containers/bit-text-mode.jsx';
 import BitFillMode from '../../components/bit-fill-mode/bit-fill-mode.jsx';
 import BitEraserMode from '../../components/bit-eraser-mode/bit-eraser-mode.jsx';
 import BitSelectMode from '../../components/bit-select-mode/bit-select-mode.jsx';
@@ -180,7 +179,7 @@ const PaintEditorComponent = props => (
                     <BitRectMode
                         onUpdateImage={props.onUpdateImage}
                     />
-                    <BitTextMode
+                    <TextMode
                         textArea={props.textArea}
                         onUpdateImage={props.onUpdateImage}
                     />

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -10,7 +10,7 @@ import BitBrushMode from '../../containers/bit-brush-mode.jsx';
 import BitLineMode from '../../containers/bit-line-mode.jsx';
 import BitOvalMode from '../../components/bit-oval-mode/bit-oval-mode.jsx';
 import BitRectMode from '../../containers/bit-rect-mode.jsx';
-import BitTextMode from '../../components/bit-text-mode/bit-text-mode.jsx';
+import BitTextMode from '../../containers/bit-text-mode.jsx';
 import BitFillMode from '../../components/bit-fill-mode/bit-fill-mode.jsx';
 import BitEraserMode from '../../components/bit-eraser-mode/bit-eraser-mode.jsx';
 import BitSelectMode from '../../components/bit-select-mode/bit-select-mode.jsx';
@@ -180,7 +180,10 @@ const PaintEditorComponent = props => (
                     <BitRectMode
                         onUpdateImage={props.onUpdateImage}
                     />
-                    <BitTextMode />
+                    <BitTextMode
+                        textArea={props.textArea}
+                        onUpdateImage={props.onUpdateImage}
+                    />
                     <BitFillMode />
                     <BitEraserMode />
                     <BitSelectMode />

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -166,7 +166,7 @@ const PaintEditorComponent = props => (
                     />
                 </div>
             ) : null}
-            
+
             {props.canvas !== null ? ( // eslint-disable-line no-negated-condition
                 <div className={isBitmap(props.format) ? styles.modeSelector : styles.hidden}>
                     <BitBrushMode
@@ -180,6 +180,7 @@ const PaintEditorComponent = props => (
                         onUpdateImage={props.onUpdateImage}
                     />
                     <TextMode
+                        isBitmap
                         textArea={props.textArea}
                         onUpdateImage={props.onUpdateImage}
                     />
@@ -192,7 +193,7 @@ const PaintEditorComponent = props => (
                     <BitSelectMode />
                 </div>
             ) : null}
-            
+
             <div>
                 {/* Canvas */}
                 <div

--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -124,6 +124,9 @@ class PaintEditor extends React.Component {
             case Modes.BIT_RECT:
                 this.props.changeMode(Modes.RECT);
                 break;
+            case Modes.BIT_TEXT:
+                this.props.changeMode(Modes.TEXT);
+                break;
             default:
                 this.props.changeMode(Modes.BRUSH);
             }
@@ -137,6 +140,9 @@ class PaintEditor extends React.Component {
                 break;
             case Modes.RECT:
                 this.props.changeMode(Modes.BIT_RECT);
+                break;
+            case Modes.TEXT:
+                this.props.changeMode(Modes.BIT_TEXT);
                 break;
             default:
                 this.props.changeMode(Modes.BIT_BRUSH);

--- a/src/containers/text-mode.jsx
+++ b/src/containers/text-mode.jsx
@@ -5,7 +5,6 @@ import {connect} from 'react-redux';
 import bindAll from 'lodash.bindall';
 import Fonts from '../lib/fonts';
 import Modes from '../lib/modes';
-import {isBitmap} from '../lib/format';
 import Formats from '../lib/format';
 import {MIXED} from '../helper/style-path';
 
@@ -66,7 +65,7 @@ class TextMode extends React.Component {
     }
     activateTool () {
         clearSelection(this.props.clearSelectedItems);
-        
+
         // If fill and stroke color are both mixed/transparent/absent, set fill to default and stroke to transparent.
         // If exactly one of fill or stroke color is set, set the other one to transparent.
         // This way the tool won't draw an invisible state, or be unclear about what will be drawn.
@@ -97,7 +96,8 @@ class TextMode extends React.Component {
         );
         this.tool.setColorState(this.props.colorState);
         this.tool.setFont(this.props.font);
-        this.tool.setFormat(this.props.format);
+        // Tool may be created before the format is changed, so trust this.props.isBitmap
+        this.tool.setFormat(this.props.isBitmap ? Formats.BITMAP : Formats.VECTOR);
         this.tool.activate();
     }
     deactivateTool () {
@@ -107,7 +107,7 @@ class TextMode extends React.Component {
     }
     render () {
         return (
-            isBitmap(this.props.format) ?
+            this.props.isBitmap ?
                 <BitTextModeComponent
                     isSelected={this.props.isTextModeActive}
                     onMouseDown={this.props.handleChangeModeBitText}
@@ -132,6 +132,7 @@ TextMode.propTypes = {
     format: PropTypes.oneOf(Object.keys(Formats)).isRequired,
     handleChangeModeBitText: PropTypes.func.isRequired,
     handleChangeModeText: PropTypes.func.isRequired,
+    isBitmap: PropTypes.bool,
     isTextModeActive: PropTypes.bool.isRequired,
     onChangeFillColor: PropTypes.func.isRequired,
     onChangeStrokeColor: PropTypes.func.isRequired,
@@ -144,11 +145,11 @@ TextMode.propTypes = {
     viewBounds: PropTypes.instanceOf(paper.Matrix).isRequired
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state, ownProps) => ({
     colorState: state.scratchPaint.color,
     font: state.scratchPaint.font,
     format: state.scratchPaint.format,
-    isTextModeActive: isBitmap(state.scratchPaint.format) ?
+    isTextModeActive: ownProps.isBitmap ?
         state.scratchPaint.mode === Modes.BIT_TEXT :
         state.scratchPaint.mode === Modes.TEXT,
     selectedItems: state.scratchPaint.selectedItems,

--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -167,7 +167,7 @@ const convertToBitmap = function (clearSelectedItems, onUpdateImage) {
     showGuideLayers(guideLayers);
 
     // Get rid of anti-aliasing
-    // @todo get crisp text?
+    // @todo get crisp text https://github.com/LLK/scratch-paint/issues/508
     svg.setAttribute('shape-rendering', 'crispEdges');
     inlineSvgFonts(svg);
     const svgString = (new XMLSerializer()).serializeToString(svg);

--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -8,13 +8,13 @@ const forEachLinePoint = function (point1, point2, callback) {
     const x2 = ~~point2.x;
     let y1 = ~~point1.y;
     const y2 = ~~point2.y;
-    
+
     const dx = Math.abs(x2 - x1);
     const dy = Math.abs(y2 - y1);
     const sx = (x1 < x2) ? 1 : -1;
     const sy = (y1 < y2) ? 1 : -1;
     let err = dx - dy;
-    
+
     callback(x1, y1);
     while (x1 !== x2 || y1 !== y2) {
         const e2 = err * 2;
@@ -45,7 +45,7 @@ const fillEllipse = function (centerX, centerY, radiusX, radiusY, context) {
     let error = 0;
     let stoppingX = twoRadYSquared * radiusX;
     let stoppingY = 0;
- 
+
     while (stoppingX >= stoppingY) {
         context.fillRect(centerX - x, centerY - y, x << 1, y << 1);
         y++;

--- a/src/helper/tools/text-tool.js
+++ b/src/helper/tools/text-tool.js
@@ -133,6 +133,8 @@ class TextTool extends paper.Tool {
             this.mode = TextTool.SELECT_MODE;
             this.textBox.selected = true;
             this.setSelectedItems();
+            // Finished editing a textbox, save undo state
+            this.onUpdateImage();
         }
     }
     /**
@@ -279,7 +281,10 @@ class TextTool extends paper.Tool {
     handleTextInput (event) {
         // Save undo state if you paused typing for long enough.
         if (this.lastTypeEvent && event.timeStamp - this.lastTypeEvent.timeStamp > TextTool.TYPING_TIMEOUT_MILLIS) {
+            // Select the textbox so that it will be selected if the user performs undo.
+            this.textBox.selected = true;
             this.onUpdateImage();
+            this.textBox.selected = false;
         }
         this.lastTypeEvent = event;
         if (this.mode === TextTool.TEXT_EDIT_MODE) {
@@ -350,17 +355,12 @@ class TextTool extends paper.Tool {
             this.eventListener = null;
         }
         this.lastTypeEvent = null;
-
-        // If you finished editing a textbox, save undo state
-        if (this.textBox && this.textBox.content.trim().length) {
-            this.onUpdateImage();
-        }
     }
     commitText () {
         if (!this.textBox || !this.textBox.parent) return;
 
         // @todo get crisp text https://github.com/LLK/scratch-paint/issues/508
-        const textRaster = this.textBox.rasterize();
+        const textRaster = this.textBox.rasterize(72, false /* insert */);
         this.textBox.remove();
         this.textBox = null;
         textRaster.onLoad = () => {

--- a/src/helper/tools/text-tool.js
+++ b/src/helper/tools/text-tool.js
@@ -51,7 +51,7 @@ class TextTool extends paper.Tool {
         this.boundingBoxTool = new BoundingBoxTool(Modes.TEXT, setSelectedItems, clearSelectedItems, onUpdateImage);
         this.nudgeTool = new NudgeTool(this.boundingBoxTool, onUpdateImage);
         this.lastEvent = null;
-        
+
         // We have to set these functions instead of just declaring them because
         // paper.js tools hook up the listeners in the setter functions.
         this.onMouseDown = this.handleMouseDown;
@@ -247,7 +247,7 @@ class TextTool extends paper.Tool {
     }
     handleMouseUp (event) {
         if (event.event.button > 0 || !this.active) return; // only first mouse button
-        
+
         if (this.mode === TextTool.SELECT_MODE) {
             this.boundingBoxTool.onMouseUp(event);
             this.isBoundingBoxMode = null;

--- a/src/helper/undo.js
+++ b/src/helper/undo.js
@@ -8,8 +8,8 @@ import log from '../log/log';
 
 /**
  * Take an undo snapshot
- * @param {!function} dispatchPerformSnapshot Callback to dispatch a state update
- * @param {!Formats} format Either Formats.BITMAP or Formats.VECTOR
+ * @param {function} dispatchPerformSnapshot Callback to dispatch a state update
+ * @param {Formats} format Either Formats.BITMAP or Formats.VECTOR
  */
 const performSnapshot = function (dispatchPerformSnapshot, format) {
     if (!format) {

--- a/src/helper/undo.js
+++ b/src/helper/undo.js
@@ -8,8 +8,8 @@ import log from '../log/log';
 
 /**
  * Take an undo snapshot
- * @param {function} dispatchPerformSnapshot Callback to dispatch a state update
- * @param {Formats} format Either Formats.BITMAP or Formats.VECTOR
+ * @param {!function} dispatchPerformSnapshot Callback to dispatch a state update
+ * @param {!Formats} format Either Formats.BITMAP or Formats.VECTOR
  */
 const performSnapshot = function (dispatchPerformSnapshot, format) {
     if (!format) {

--- a/src/lib/modes.js
+++ b/src/lib/modes.js
@@ -4,6 +4,7 @@ const Modes = keyMirror({
     BIT_BRUSH: null,
     BIT_LINE: null,
     BIT_RECT: null,
+    BIT_TEXT: null,
     BRUSH: null,
     ERASER: null,
     LINE: null,
@@ -19,7 +20,8 @@ const Modes = keyMirror({
 const BitmapModes = keyMirror({
     BIT_BRUSH: null,
     BIT_LINE: null,
-    BIT_RECT: null
+    BIT_RECT: null,
+    BIT_TEXT: null
 });
 
 export {


### PR DESCRIPTION
Adds the text tool in bitmap mode. It uses the exact same tool as vector, I've just added a step where when you exit both text and selection mode, and the format is bitmap, the vector is transferred to the bitmap layer.

There was an important bug to fix, which was that undoing into a text-edit state left the text unselected. This was fine in vector, but in bitmap it leaves around a vector that it's not obvious isn't part of the bitmap yet. So I've added logic to make text selected when you undo into a state where the text is still vector.