### PR TITLE
Increase selected tool visibility by making the icon white and bg blue.

### DIFF
--- a/src/components/tool-select-base/tool-select-base.css
+++ b/src/components/tool-select-base/tool-select-base.css
@@ -16,7 +16,7 @@ $border-radius: .25rem;
 }
 
 .mod-tool-select.is-selected {
-    background-color: $motion-transparent;
+    background-color: $motion-primary;
 }
 
 .mod-tool-select:focus {
@@ -28,6 +28,11 @@ img.tool-select-icon {
     height: 2rem;
     flex-grow: 1;
     vertical-align: middle;
+}
+
+.mod-tool-select.is-selected .tool-select-icon {
+    /* Make the tool icons white while selected by making them black and inverting */
+    filter: brightness(0) invert(1);
 }
 
 @media only screen and (max-width: $full-size-paint) {


### PR DESCRIPTION

### Resolves

_What Github issue does this resolve (please include link)?_

Resolves #375

### Proposed Changes

_Describe what this Pull Request does_

Increase selected tool visibility by making the icon white and bg blue.
![image](https://user-images.githubusercontent.com/654102/42092406-d2112a98-7b76-11e8-851b-2d7b113f3ae9.png)
![image](https://user-images.githubusercontent.com/654102/42092407-d34ff010-7b76-11e8-9d0a-b6774a4d3489.png)

Tested on Chrome, Firefox, Safari, Edge