### PR TITLE
Correct the view bounds when the paper canvas is initialized.

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -37,6 +37,7 @@ class PaperCanvas extends React.Component {
         document.addEventListener('keydown', this.handleKeyDown);
         paper.setup(this.canvas);
         resetZoom();
+        this.props.updateViewBounds(paper.view.matrix);
 
         const context = this.canvas.getContext('2d');
         context.webkitImageSmoothingEnabled = false;


### PR DESCRIPTION
View bounds is initialized to the identity matrix, but paper actually starts out at 50% zoom (due to having to handle double resolution bitmaps). This would cause updateViewBounds to not trigger its listeners if you pressed the zoom in button (which actually does bring the zoom to %100)