### PR TITLE
Make the bitmap/vector conversion button look enabled

### DIFF
--- a/src/components/paint-editor/paint-editor.css
+++ b/src/components/paint-editor/paint-editor.css
@@ -140,12 +140,6 @@ $border-radius: 0.25rem;
     font-weight: bold;
     color: white;
     justify-content: center;
-    opacity: .75;
-}
-
-.bitmap-button:active {
-    background-color: $motion-primary;
-    opacity: 1;
 }
 
 .bitmap-button-icon {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-gui/issues/2589

### Proposed Changes

_Describe what this Pull Request does_

Don't change the opacity of this button, it is always enabled. Remove the active state, which seems like it was made in error, probably mistaken for `enabled`. But now the button is always enabled, so just don't modify the opacity.

### Reason for Changes

_Explain why these changes should be made_

It looked disabled.

### Test Coverage

_Please show how you have added tests to cover your changes_

![image](https://user-images.githubusercontent.com/654102/42639623-6f4528ea-85be-11e8-8ead-8c2c97880a16.png)

/cc @thisandagain 