### PR TITLE
Adjust format for different locales

### DIFF
--- a/src/components/fixed-tools/fixed-tools.jsx
+++ b/src/components/fixed-tools/fixed-tools.jsx
@@ -19,6 +19,7 @@ import Label from '../forms/label.jsx';
 import LabeledIconButton from '../labeled-icon-button/labeled-icon-button.jsx';
 import {isVector} from '../../lib/format';
 import layout from '../../lib/layout-constants';
+import {hideLabel} from '../../lib/hide-label';
 import styles from './fixed-tools.css';
 
 import groupIcon from './icons/group.svg';
@@ -161,12 +162,14 @@ const FixedToolsComponent = props => {
                 <InputGroup className={styles.modDashedBorder}>
                     <LabeledIconButton
                         disabled={!shouldShowGroup()}
+                        hideLabel={hideLabel(props.intl.locale)}
                         imgSrc={groupIcon}
                         title={props.intl.formatMessage(messages.group)}
                         onClick={props.onGroup}
                     />
                     <LabeledIconButton
                         disabled={!shouldShowUngroup()}
+                        hideLabel={hideLabel(props.intl.locale)}
                         imgSrc={ungroupIcon}
                         title={props.intl.formatMessage(messages.ungroup)}
                         onClick={props.onUngroup}
@@ -179,12 +182,14 @@ const FixedToolsComponent = props => {
                 <InputGroup className={styles.modDashedBorder}>
                     <LabeledIconButton
                         disabled={!shouldShowBringForward()}
+                        hideLabel={hideLabel(props.intl.locale)}
                         imgSrc={sendForwardIcon}
                         title={props.intl.formatMessage(messages.forward)}
                         onClick={props.onSendForward}
                     />
                     <LabeledIconButton
                         disabled={!shouldShowSendBackward()}
+                        hideLabel={hideLabel(props.intl.locale)}
                         imgSrc={sendBackwardIcon}
                         title={props.intl.formatMessage(messages.backward)}
                         onClick={props.onSendBackward}
@@ -197,12 +202,14 @@ const FixedToolsComponent = props => {
                     <InputGroup className={styles.row}>
                         <LabeledIconButton
                             disabled={!shouldShowBringForward()}
+                            hideLabel={hideLabel(props.intl.locale)}
                             imgSrc={sendFrontIcon}
                             title={props.intl.formatMessage(messages.front)}
                             onClick={props.onSendToFront}
                         />
                         <LabeledIconButton
                             disabled={!shouldShowSendBackward()}
+                            hideLabel={hideLabel(props.intl.locale)}
                             imgSrc={sendBackIcon}
                             title={props.intl.formatMessage(messages.back)}
                             onClick={props.onSendToBack}

--- a/src/components/labeled-icon-button/labeled-icon-button.jsx
+++ b/src/components/labeled-icon-button/labeled-icon-button.jsx
@@ -12,6 +12,7 @@ import styles from './labeled-icon-button.css';
 
 const LabeledIconButton = ({
     className,
+    hideLabel,
     imgAlt,
     imgSrc,
     onClick,
@@ -24,17 +25,19 @@ const LabeledIconButton = ({
         {...props}
     >
         <img
-            alt={imgAlt}
+            alt={imgAlt || title}
             className={styles.editFieldIcon}
             draggable={false}
             src={imgSrc}
+            title={title}
         />
-        <span className={styles.editFieldTitle}>{title}</span>
+        {!hideLabel && <span className={styles.editFieldTitle}>{title}</span>}
     </Button>
 );
 
 LabeledIconButton.propTypes = {
     className: PropTypes.string,
+    hideLabel: PropTypes.bool,
     highlighted: PropTypes.bool,
     imgAlt: PropTypes.string,
     imgSrc: PropTypes.string.isRequired,

--- a/src/components/mode-tools/mode-tools.css
+++ b/src/components/mode-tools/mode-tools.css
@@ -19,5 +19,7 @@
 }
 
 .mod-labeled-icon-height {
+    display: flex;
     height: 2.85rem; /* for the second row so the dashed borders are equal in size */
+    align-items: center;
 }

--- a/src/components/mode-tools/mode-tools.jsx
+++ b/src/components/mode-tools/mode-tools.jsx
@@ -20,6 +20,7 @@ import LabeledIconButton from '../labeled-icon-button/labeled-icon-button.jsx';
 import Modes from '../../lib/modes';
 import Formats from '../../lib/format';
 import {isBitmap, isVector} from '../../lib/format';
+import {hideLabel} from '../../lib/hide-label';
 import styles from './mode-tools.css';
 
 import copyIcon from './icons/copy.svg';
@@ -176,12 +177,14 @@ const ModeToolsComponent = props => {
                 <InputGroup className={classNames(styles.modDashedBorder, styles.modLabeledIconHeight)}>
                     <LabeledIconButton
                         disabled={!props.hasSelectedUncurvedPoints}
+                        hideLabel={hideLabel(props.intl.locale)}
                         imgSrc={curvedPointIcon}
                         title={props.intl.formatMessage(messages.curved)}
                         onClick={props.onCurvePoints}
                     />
                     <LabeledIconButton
                         disabled={!props.hasSelectedUnpointedPoints}
+                        hideLabel={hideLabel(props.intl.locale)}
                         imgSrc={straightPointIcon}
                         title={props.intl.formatMessage(messages.pointed)}
                         onClick={props.onPointPoints}
@@ -190,6 +193,7 @@ const ModeToolsComponent = props => {
                 <InputGroup className={classNames(styles.modLabeledIconHeight)}>
                     <LabeledIconButton
                         disabled={!props.selectedItems.length}
+                        hideLabel={hideLabel(props.intl.locale)}
                         imgSrc={deleteIcon}
                         title={props.intl.formatMessage(messages.delete)}
                         onClick={props.onDelete}
@@ -205,12 +209,14 @@ const ModeToolsComponent = props => {
                 <InputGroup className={classNames(styles.modDashedBorder, styles.modLabeledIconHeight)}>
                     <LabeledIconButton
                         disabled={!props.selectedItems.length}
+                        hideLabel={hideLabel(props.intl.locale)}
                         imgSrc={copyIcon}
                         title={props.intl.formatMessage(messages.copy)}
                         onClick={props.onCopyToClipboard}
                     />
                     <LabeledIconButton
                         disabled={!(props.clipboardItems.length > 0)}
+                        hideLabel={hideLabel(props.intl.locale)}
                         imgSrc={pasteIcon}
                         title={props.intl.formatMessage(messages.paste)}
                         onClick={props.onPasteFromClipboard}
@@ -219,6 +225,7 @@ const ModeToolsComponent = props => {
                 <InputGroup className={classNames(styles.modDashedBorder, styles.modLabeledIconHeight)}>
                     <LabeledIconButton
                         disabled={!props.selectedItems.length}
+                        hideLabel={hideLabel(props.intl.locale)}
                         imgSrc={deleteIcon}
                         title={props.intl.formatMessage(messages.delete)}
                         onClick={props.onDelete}
@@ -226,11 +233,13 @@ const ModeToolsComponent = props => {
                 </InputGroup>
                 <InputGroup className={classNames(styles.modLabeledIconHeight)}>
                     <LabeledIconButton
+                        hideLabel={props.intl.locale !== 'en'}
                         imgSrc={flipHorizontalIcon}
                         title={props.intl.formatMessage(messages.flipHorizontal)}
                         onClick={props.onFlipHorizontal}
                     />
                     <LabeledIconButton
+                        hideLabel={props.intl.locale !== 'en'}
                         imgSrc={flipVerticalIcon}
                         title={props.intl.formatMessage(messages.flipVertical)}
                         onClick={props.onFlipVertical}

--- a/src/lib/hide-label.js
+++ b/src/lib/hide-label.js
@@ -1,0 +1,31 @@
+const localeTooBig = [
+    'ab',
+    'ca',
+    'cy',
+    'de',
+    'et',
+    'el',
+    'ga',
+    'gl',
+    'mi',
+    'nl',
+    'ja',
+    'ja-Hira',
+    'nb',
+    'nn',
+    'th',
+    'sr',
+    'sk',
+    'sl',
+    'fi',
+    'sv',
+    'vi',
+    'tr',
+    'uk'
+];
+
+const hideLabel = locale => localeTooBig.includes(locale);
+
+export {
+    hideLabel
+};

--- a/src/lib/layout-constants.js
+++ b/src/lib/layout-constants.js
@@ -1,3 +1,3 @@
 export default {
-    fullSizeEditorMinWidth: 1250
+    fullSizeEditorMinWidth: 1274
 };


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Resolves #543 

### Proposed Changes

_Describe what this Pull Request does_
* increased fullsize editor width, English required 1272px, adding a couple more pixels allowed a couple of other languages to keep labels
* hide flip vertical/horizontal labels for everything except English
* hide all labels for languages defined in `hideLabel`

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_
Current tests run - further testing will need to happen in gui with all the languages.