### PR TITLE
Selection limit

### DIFF
--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -659,11 +659,6 @@ const scaleBitmap = function (canvas, scale) {
  * @param {paper.Raster} item raster to change
  */
 const maybeApplyScaleToCanvas_ = function (item) {
-    if (!item.matrix.isInvertible()) {
-        item.remove();
-        return;
-    }
-
     // context.drawImage will anti-alias the image if both width and height are reduced.
     // However, it will preserve pixel colors if only one or the other is reduced, and
     // imageSmoothingEnabled is set to false. Therefore, we can avoid aliasing by scaling
@@ -719,6 +714,10 @@ const commitArbitraryTransformation_ = function (item, destination) {
  * @param {paper.Raster} bitmap raster to draw selection to
  */
 const commitSelectionToBitmap = function (selection, bitmap) {
+    if (!selection.matrix.isInvertible()) {
+        return;
+    }
+
     maybeApplyScaleToCanvas_(selection);
     commitArbitraryTransformation_(selection, bitmap);
 };

--- a/src/helper/selection-tools/selection-box-tool.js
+++ b/src/helper/selection-tools/selection-box-tool.js
@@ -2,6 +2,7 @@ import paper from '@scratch/paper';
 import {rectSelect} from '../guides';
 import {clearSelection, processRectangularSelection} from '../selection';
 import {getRaster} from '../layer';
+import {ART_BOARD_WIDTH, ART_BOARD_HEIGHT} from '../view';
 
 /** Tool to handle drag selection. A dotted line box appears and everything enclosed is selected. */
 class SelectionBoxTool {
@@ -44,12 +45,14 @@ class SelectionBoxTool {
     onMouseUpBitmap (event) {
         if (event.event.button > 0) return; // only first mouse button
         if (this.selectionRect) {
-            const rect = new paper.Rectangle(
-                Math.round(this.selectionRect.bounds.x),
-                Math.round(this.selectionRect.bounds.y),
-                Math.round(this.selectionRect.bounds.width),
-                Math.round(this.selectionRect.bounds.height),
-            );
+            const rect = new paper.Rectangle({
+                from: new paper.Point(
+                    Math.max(0, Math.round(this.selectionRect.bounds.topLeft.x)),
+                    Math.max(0, Math.round(this.selectionRect.bounds.topLeft.y))),
+                to: new paper.Point(
+                    Math.min(ART_BOARD_WIDTH, Math.round(this.selectionRect.bounds.bottomRight.x)),
+                    Math.min(ART_BOARD_HEIGHT, Math.round(this.selectionRect.bounds.bottomRight.y)))
+            });
 
             // Remove dotted rectangle
             this.selectionRect.remove();


### PR DESCRIPTION
### Resolves
Some clean-up to go with https://github.com/LLK/paper.js/pull/16
- When selection exceeds bounds, resize it to end at the bounds of the paint editor.
- Move the check for matrix invertibility to the top of commitSelectionToBitmap. We shouldn't have non-invertible matrices, but if we did, we should skip the whole function. Item.remove() is handled inside the select tool so it isn't necessary.
