### PR TITLE
Double click in select modes switches to text tool

### DIFF
--- a/src/containers/reshape-mode.jsx
+++ b/src/containers/reshape-mode.jsx
@@ -45,7 +45,8 @@ class ReshapeMode extends React.Component {
             this.props.clearHoveredItem,
             this.props.setSelectedItems,
             this.props.clearSelectedItems,
-            this.props.onUpdateImage
+            this.props.onUpdateImage,
+            this.props.switchToTextTool
         );
         this.tool.setPrevHoveredItemId(this.props.hoveredItemId);
         this.tool.activate();
@@ -74,7 +75,8 @@ ReshapeMode.propTypes = {
     isReshapeModeActive: PropTypes.bool.isRequired,
     onUpdateImage: PropTypes.func.isRequired,
     setHoveredItem: PropTypes.func.isRequired,
-    setSelectedItems: PropTypes.func.isRequired
+    setSelectedItems: PropTypes.func.isRequired,
+    switchToTextTool: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
@@ -96,6 +98,9 @@ const mapDispatchToProps = dispatch => ({
     },
     handleMouseDown: () => {
         dispatch(changeMode(Modes.RESHAPE));
+    },
+    switchToTextTool: () => {
+        dispatch(changeMode(Modes.TEXT));
     }
 });
 

--- a/src/containers/select-mode.jsx
+++ b/src/containers/select-mode.jsx
@@ -49,7 +49,8 @@ class SelectMode extends React.Component {
             this.props.clearHoveredItem,
             this.props.setSelectedItems,
             this.props.clearSelectedItems,
-            this.props.onUpdateImage
+            this.props.onUpdateImage,
+            this.props.switchToTextTool
         );
         this.tool.activate();
     }
@@ -77,7 +78,8 @@ SelectMode.propTypes = {
     onUpdateImage: PropTypes.func.isRequired,
     selectedItems: PropTypes.arrayOf(PropTypes.instanceOf(paper.Item)),
     setHoveredItem: PropTypes.func.isRequired,
-    setSelectedItems: PropTypes.func.isRequired
+    setSelectedItems: PropTypes.func.isRequired,
+    switchToTextTool: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
@@ -100,6 +102,9 @@ const mapDispatchToProps = dispatch => ({
     },
     handleMouseDown: () => {
         dispatch(changeMode(Modes.SELECT));
+    },
+    switchToTextTool: () => {
+        dispatch(changeMode(Modes.TEXT));
     }
 });
 

--- a/src/containers/text-mode.jsx
+++ b/src/containers/text-mode.jsx
@@ -60,6 +60,11 @@ class TextMode extends React.Component {
         return nextProps.isTextModeActive !== this.props.isTextModeActive;
     }
     activateTool (nextProps) {
+        const selected = getSelectedLeafItems();
+        let textBoxToStartEditing = null;
+        if (selected.length === 1 && selected[0] instanceof paper.PointText) {
+            textBoxToStartEditing = selected[0];
+        }
         clearSelection(this.props.clearSelectedItems);
         this.props.clearGradient();
 
@@ -95,6 +100,10 @@ class TextMode extends React.Component {
         this.tool.setColorState(nextProps.colorState);
         this.tool.setFont(nextProps.font);
         this.tool.activate();
+        if (textBoxToStartEditing) {
+            this.tool.beginTextEdit(textBoxToStartEditing);
+            this.props.textArea.select();
+        }
     }
     deactivateTool () {
         this.tool.deactivateTool();

--- a/src/helper/bit-tools/oval-tool.js
+++ b/src/helper/bit-tools/oval-tool.js
@@ -25,7 +25,7 @@ class OvalTool extends paper.Tool {
         this.onUpdateImage = onUpdateImage;
         this.boundingBoxTool = new BoundingBoxTool(Modes.BIT_OVAL, setSelectedItems, clearSelectedItems, onUpdateImage);
         const nudgeTool = new NudgeTool(this.boundingBoxTool, onUpdateImage);
-        
+
         // We have to set these functions instead of just declaring them because
         // paper.js tools hook up the listeners in the setter functions.
         this.onMouseDown = this.handleMouseDown;
@@ -105,7 +105,8 @@ class OvalTool extends paper.Tool {
         if (event.event.button > 0) return; // only first mouse button
         this.active = true;
 
-        if (this.boundingBoxTool.onMouseDown(event, false /* clone */, false /* multiselect */, this.getHitOptions())) {
+        if (this.boundingBoxTool.onMouseDown(
+            event, false /* clone */, false /* multiselect */, false /* doubleClicked */, this.getHitOptions())) {
             this.isBoundingBoxMode = true;
         } else {
             this.isBoundingBoxMode = false;
@@ -151,11 +152,11 @@ class OvalTool extends paper.Tool {
         } else {
             this.oval.position = downPoint.subtract(this.oval.size.multiply(0.5));
         }
-        
+
     }
     handleMouseUp (event) {
         if (event.event.button > 0 || !this.active) return; // only first mouse button
-        
+
         if (this.isBoundingBoxMode) {
             this.boundingBoxTool.onMouseUp(event);
             this.isBoundingBoxMode = null;

--- a/src/helper/bit-tools/rect-tool.js
+++ b/src/helper/bit-tools/rect-tool.js
@@ -105,7 +105,8 @@ class RectTool extends paper.Tool {
         if (event.event.button > 0) return; // only first mouse button
         this.active = true;
 
-        if (this.boundingBoxTool.onMouseDown(event, false /* clone */, false /* multiselect */, this.getHitOptions())) {
+        if (this.boundingBoxTool.onMouseDown(
+            event, false /* clone */, false /* multiselect */, false /* doubleClicked */, this.getHitOptions())) {
             this.isBoundingBoxMode = true;
         } else {
             this.isBoundingBoxMode = false;

--- a/src/helper/bit-tools/select-tool.js
+++ b/src/helper/bit-tools/select-tool.js
@@ -88,6 +88,7 @@ class SelectTool extends paper.Tool {
                 event,
                 event.modifiers.alt,
                 event.modifiers.shift,
+                false /* doubleClicked */,
                 this.getHitOptions())) {
             this.commitSelection();
             this.selectionBoxMode = true;

--- a/src/helper/selection-tools/bounding-box-tool.js
+++ b/src/helper/selection-tools/bounding-box-tool.js
@@ -67,7 +67,7 @@ class BoundingBoxTool {
      * @param {!MouseEvent} event The mouse event
      * @param {boolean} clone Whether to clone on mouse down (e.g. alt key held)
      * @param {boolean} multiselect Whether to multiselect on mouse down (e.g. shift key held)
-     * @param {?boolean} hitProperties.doubleClicked True if this is the second click in a short amout of time
+     * @param {?boolean} doubleClicked True if this is the second click in a short amout of time
      * @param {paper.hitOptions} hitOptions The options with which to detect whether mouse down has hit
      *     anything editable
      * @return {boolean} True if there was a hit, false otherwise

--- a/src/helper/selection-tools/bounding-box-tool.js
+++ b/src/helper/selection-tools/bounding-box-tool.js
@@ -36,8 +36,9 @@ class BoundingBoxTool {
      * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
      * @param {function} clearSelectedItems Callback to clear the set of selected items in the Redux state
      * @param {!function} onUpdateImage A callback to call when the image visibly changes
+     * @param {?function} switchToTextTool A callback to call to switch to the text tool
      */
-    constructor (mode, setSelectedItems, clearSelectedItems, onUpdateImage) {
+    constructor (mode, setSelectedItems, clearSelectedItems, onUpdateImage, switchToTextTool) {
         this.onUpdateImage = onUpdateImage;
         this.mode = null;
         this.boundsPath = null;
@@ -46,7 +47,8 @@ class BoundingBoxTool {
         this._modeMap = {};
         this._modeMap[BoundingBoxModes.SCALE] = new ScaleTool(onUpdateImage);
         this._modeMap[BoundingBoxModes.ROTATE] = new RotateTool(onUpdateImage);
-        this._modeMap[BoundingBoxModes.MOVE] = new MoveTool(mode, setSelectedItems, clearSelectedItems, onUpdateImage);
+        this._modeMap[BoundingBoxModes.MOVE] =
+            new MoveTool(mode, setSelectedItems, clearSelectedItems, onUpdateImage, switchToTextTool);
     }
 
     /**
@@ -65,11 +67,12 @@ class BoundingBoxTool {
      * @param {!MouseEvent} event The mouse event
      * @param {boolean} clone Whether to clone on mouse down (e.g. alt key held)
      * @param {boolean} multiselect Whether to multiselect on mouse down (e.g. shift key held)
+     * @param {?boolean} hitProperties.doubleClicked True if this is the second click in a short amout of time
      * @param {paper.hitOptions} hitOptions The options with which to detect whether mouse down has hit
      *     anything editable
      * @return {boolean} True if there was a hit, false otherwise
      */
-    onMouseDown (event, clone, multiselect, hitOptions) {
+    onMouseDown (event, clone, multiselect, doubleClicked, hitOptions) {
         if (event.event.button > 0) return; // only first mouse button
         const hitResults = paper.project.hitTestAll(event.point, hitOptions);
         if (!hitResults || hitResults.length === 0) {
@@ -98,7 +101,8 @@ class BoundingBoxTool {
         const hitProperties = {
             hitResult: hitResult,
             clone: clone,
-            multiselect: multiselect
+            multiselect: multiselect,
+            doubleClicked: doubleClicked
         };
         if (this.mode === BoundingBoxModes.MOVE) {
             this._modeMap[this.mode].onMouseDown(hitProperties);

--- a/src/helper/selection-tools/move-tool.js
+++ b/src/helper/selection-tools/move-tool.js
@@ -1,3 +1,4 @@
+import paper from '@scratch/paper';
 import Modes from '../../lib/modes';
 import {isGroup} from '../group';
 import {isCompoundPathItem, getRootItem} from '../item';
@@ -14,13 +15,15 @@ class MoveTool {
      * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
      * @param {function} clearSelectedItems Callback to clear the set of selected items in the Redux state
      * @param {!function} onUpdateImage A callback to call when the image visibly changes
+     * @param {?function} switchToTextTool A callback to call to switch to the text tool
      */
-    constructor (mode, setSelectedItems, clearSelectedItems, onUpdateImage) {
+    constructor (mode, setSelectedItems, clearSelectedItems, onUpdateImage, switchToTextTool) {
         this.mode = mode;
         this.setSelectedItems = setSelectedItems;
         this.clearSelectedItems = clearSelectedItems;
         this.selectedItems = null;
         this.onUpdateImage = onUpdateImage;
+        this.switchToTextTool = switchToTextTool;
         this.boundsPath = null;
     }
 
@@ -40,9 +43,14 @@ class MoveTool {
             item = isCompoundPathItem(root) || isGroup(root) ? root : hitProperties.hitResult.item;
         }
         if (item.selected) {
-            // Double click causes all points to be selected in subselect mode.
+            // Double click causes all points to be selected in subselect mode. If the target is text, it
+            // enters text edit.
             if (hitProperties.doubleClicked) {
                 if (!hitProperties.multiselect) {
+                    if (this.switchToTextTool && item instanceof paper.PointText) {
+                        this.switchToTextTool();
+                        return;
+                    }
                     clearSelection(this.clearSelectedItems);
                 }
                 this._select(item, true /* state */, hitProperties.subselect, true /* fullySelect */);

--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -44,8 +44,10 @@ class ReshapeTool extends paper.Tool {
      * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
      * @param {function} clearSelectedItems Callback to clear the set of selected items in the Redux state
      * @param {!function} onUpdateImage A callback to call when the image visibly changes
+     * @param {!function} switchToTextTool A callback to call to switch to the text tool
      */
-    constructor (setHoveredItem, clearHoveredItem, setSelectedItems, clearSelectedItems, onUpdateImage) {
+    constructor (setHoveredItem, clearHoveredItem, setSelectedItems, clearSelectedItems, onUpdateImage,
+            switchToTextTool) {
         super();
         this.setHoveredItem = setHoveredItem;
         this.clearHoveredItem = clearHoveredItem;
@@ -56,7 +58,7 @@ class ReshapeTool extends paper.Tool {
         this.mode = ReshapeModes.SELECTION_BOX;
         this._modeMap = {};
         this._modeMap[ReshapeModes.FILL] =
-            new MoveTool(Modes.RESHAPE, setSelectedItems, clearSelectedItems, onUpdateImage);
+            new MoveTool(Modes.RESHAPE, setSelectedItems, clearSelectedItems, onUpdateImage, switchToTextTool);
         this._modeMap[ReshapeModes.POINT] = new PointTool(setSelectedItems, clearSelectedItems, onUpdateImage);
         this._modeMap[ReshapeModes.HANDLE] = new HandleTool(setSelectedItems, clearSelectedItems, onUpdateImage);
         this._modeMap[ReshapeModes.SELECTION_BOX] =
@@ -169,7 +171,7 @@ class ReshapeTool extends paper.Tool {
                 break;
             }
         }
-        
+
         // Don't allow detail-selection of PGTextItem
         if (isPGTextItem(getRootItem(hitResult.item))) {
             return;
@@ -209,7 +211,7 @@ class ReshapeTool extends paper.Tool {
             this.mode = ReshapeModes.FILL;
             this._modeMap[this.mode].onMouseDown(hitProperties);
         }
-    
+
         // @todo Trigger selection changed. Update styles based on selection.
     }
     handleMouseMove (event) {

--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -47,7 +47,7 @@ class ReshapeTool extends paper.Tool {
      * @param {!function} switchToTextTool A callback to call to switch to the text tool
      */
     constructor (setHoveredItem, clearHoveredItem, setSelectedItems, clearSelectedItems, onUpdateImage,
-            switchToTextTool) {
+        switchToTextTool) {
         super();
         this.setHoveredItem = setHoveredItem;
         this.clearHoveredItem = clearHoveredItem;

--- a/src/helper/selection-tools/select-tool.js
+++ b/src/helper/selection-tools/select-tool.js
@@ -32,7 +32,7 @@ class SelectTool extends paper.Tool {
      * @param {!function} switchToTextTool A callback to call to switch to the text tool
      */
     constructor (setHoveredItem, clearHoveredItem, setSelectedItems, clearSelectedItems, onUpdateImage,
-            switchToTextTool) {
+        switchToTextTool) {
         super();
         this.setHoveredItem = setHoveredItem;
         this.clearHoveredItem = clearHoveredItem;

--- a/src/helper/tools/oval-tool.js
+++ b/src/helper/tools/oval-tool.js
@@ -24,7 +24,7 @@ class OvalTool extends paper.Tool {
         this.onUpdateImage = onUpdateImage;
         this.boundingBoxTool = new BoundingBoxTool(Modes.OVAL, setSelectedItems, clearSelectedItems, onUpdateImage);
         const nudgeTool = new NudgeTool(this.boundingBoxTool, onUpdateImage);
-        
+
         // We have to set these functions instead of just declaring them because
         // paper.js tools hook up the listeners in the setter functions.
         this.onMouseDown = this.handleMouseDown;
@@ -65,7 +65,8 @@ class OvalTool extends paper.Tool {
         if (event.event.button > 0) return; // only first mouse button
         this.active = true;
 
-        if (this.boundingBoxTool.onMouseDown(event, false /* clone */, false /* multiselect */, this.getHitOptions())) {
+        if (this.boundingBoxTool.onMouseDown(
+            event, false /* clone */, false /* multiselect */, false /* doubleClicked */, this.getHitOptions())) {
             this.isBoundingBoxMode = true;
         } else {
             this.isBoundingBoxMode = false;
@@ -97,11 +98,11 @@ class OvalTool extends paper.Tool {
         } else {
             this.oval.position = downPoint.subtract(this.oval.size.multiply(0.5));
         }
-        
+
     }
     handleMouseUp (event) {
         if (event.event.button > 0 || !this.active) return; // only first mouse button
-        
+
         if (this.isBoundingBoxMode) {
             this.boundingBoxTool.onMouseUp(event);
             this.isBoundingBoxMode = null;

--- a/src/helper/tools/rect-tool.js
+++ b/src/helper/tools/rect-tool.js
@@ -24,7 +24,7 @@ class RectTool extends paper.Tool {
         this.onUpdateImage = onUpdateImage;
         this.boundingBoxTool = new BoundingBoxTool(Modes.RECT, setSelectedItems, clearSelectedItems, onUpdateImage);
         const nudgeTool = new NudgeTool(this.boundingBoxTool, onUpdateImage);
-        
+
         // We have to set these functions instead of just declaring them because
         // paper.js tools hook up the listeners in the setter functions.
         this.onMouseDown = this.handleMouseDown;
@@ -65,7 +65,8 @@ class RectTool extends paper.Tool {
         if (event.event.button > 0) return; // only first mouse button
         this.active = true;
 
-        if (this.boundingBoxTool.onMouseDown(event, false /* clone */, false /* multiselect */, this.getHitOptions())) {
+        if (this.boundingBoxTool.onMouseDown(
+            event, false /* clone */, false /* multiselect */, false /* doubleClicked */, this.getHitOptions())) {
             this.isBoundingBoxMode = true;
         } else {
             this.isBoundingBoxMode = false;
@@ -91,18 +92,18 @@ class RectTool extends paper.Tool {
             dimensions.y = event.downPoint.y > event.point.y ? -Math.abs(rect.width) : Math.abs(rect.width);
         }
         this.rect = new paper.Path.Rectangle(rect);
-        
+
         if (event.modifiers.alt) {
             this.rect.position = event.downPoint;
         } else {
             this.rect.position = event.downPoint.add(dimensions.multiply(.5));
         }
-        
+
         styleShape(this.rect, this.colorState);
     }
     handleMouseUp (event) {
         if (event.event.button > 0 || !this.active) return; // only first mouse button
-        
+
         if (this.isBoundingBoxMode) {
             this.boundingBoxTool.onMouseUp(event);
             this.isBoundingBoxMode = null;


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/461

### Proposed Changes
Double clicking on a text item in select or reshape mode switches you to the text tool

This implementation has the somewhat weird side effect that if you have a text item and only a text item selected in select mode, and then you switch to the text tool by clicking on the text tool, it still enters text edit mode on the box. Does that seem reasonable?