### PR TITLE
Reduce hit tolerance

### DIFF
--- a/src/helper/bit-tools/oval-tool.js
+++ b/src/helper/bit-tools/oval-tool.js
@@ -11,7 +11,7 @@ import NudgeTool from '../selection-tools/nudge-tool';
  */
 class OvalTool extends paper.Tool {
     static get TOLERANCE () {
-        return 6;
+        return 2;
     }
     /**
      * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
@@ -46,8 +46,8 @@ class OvalTool extends paper.Tool {
             fill: true,
             guide: false,
             match: hitResult =>
-                (hitResult.item.data && hitResult.item.data.isHelperItem) ||
-                    hitResult.item === this.oval, // Allow hits on bounding box and oval only
+                (hitResult.item.data && (hitResult.item.data.isScaleHandle || hitResult.item.data.isRotHandle)) ||
+                hitResult.item.selected, // Allow hits on bounding box and selected only
             tolerance: OvalTool.TOLERANCE / paper.view.zoom
         };
     }

--- a/src/helper/bit-tools/rect-tool.js
+++ b/src/helper/bit-tools/rect-tool.js
@@ -11,7 +11,7 @@ import NudgeTool from '../selection-tools/nudge-tool';
  */
 class RectTool extends paper.Tool {
     static get TOLERANCE () {
-        return 6;
+        return 2;
     }
     /**
      * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
@@ -46,8 +46,8 @@ class RectTool extends paper.Tool {
             fill: true,
             guide: false,
             match: hitResult =>
-                (hitResult.item.data && hitResult.item.data.isHelperItem) ||
-                    hitResult.item === this.rect, // Allow hits on bounding box and rect only
+                (hitResult.item.data && (hitResult.item.data.isScaleHandle || hitResult.item.data.isRotHandle)) ||
+                hitResult.item.selected, // Allow hits on bounding box and selected only
             tolerance: RectTool.TOLERANCE / paper.view.zoom
         };
     }

--- a/src/helper/bit-tools/select-tool.js
+++ b/src/helper/bit-tools/select-tool.js
@@ -18,7 +18,7 @@ import SelectionBoxTool from '../selection-tools/selection-box-tool';
 class SelectTool extends paper.Tool {
     /** The distance within which mouse events count as a hit against an item */
     static get TOLERANCE () {
-        return 6;
+        return 2;
     }
     /**
      * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
@@ -74,7 +74,12 @@ class SelectTool extends paper.Tool {
             curves: true,
             fill: true,
             guide: false,
-            tolerance: SelectTool.TOLERANCE / paper.view.zoom
+            tolerance: SelectTool.TOLERANCE / paper.view.zoom,
+            match: hitResult => {
+                // Don't match helper items, unless they are handles.
+                if (!hitResult.item.data || !hitResult.item.data.isHelperItem) return true;
+                return hitResult.item.data.isScaleHandle || hitResult.item.data.isRotHandle;
+            }
         };
     }
     handleMouseDown (event) {

--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -32,7 +32,7 @@ const ReshapeModes = keyMirror({
 class ReshapeTool extends paper.Tool {
     /** Distance within which mouse is considered to be hitting an item */
     static get TOLERANCE () {
-        return 8;
+        return 4;
     }
     /** Clicks registered within this amount of time are registered as double clicks */
     static get DOUBLE_CLICK_MILLIS () {

--- a/src/helper/selection-tools/select-tool.js
+++ b/src/helper/selection-tools/select-tool.js
@@ -17,7 +17,7 @@ import paper from '@scratch/paper';
 class SelectTool extends paper.Tool {
     /** The distance within which mouse events count as a hit against an item */
     static get TOLERANCE () {
-        return 6;
+        return 2;
     }
     /** Clicks registered within this amount of time are registered as double clicks */
     static get DOUBLE_CLICK_MILLIS () {
@@ -90,7 +90,12 @@ class SelectTool extends paper.Tool {
             curves: true,
             fill: true,
             guide: false,
-            tolerance: SelectTool.TOLERANCE / paper.view.zoom
+            tolerance: SelectTool.TOLERANCE / paper.view.zoom,
+            match: hitResult => {
+                // Don't match helper items, unless they are handles.
+                if (!hitResult.item.data || !hitResult.item.data.isHelperItem) return true;
+                return hitResult.item.data.isScaleHandle || hitResult.item.data.isRotHandle;
+            }
         };
         if (preselectedOnly) {
             hitOptions.selected = true;

--- a/src/helper/tools/oval-tool.js
+++ b/src/helper/tools/oval-tool.js
@@ -10,7 +10,7 @@ import NudgeTool from '../selection-tools/nudge-tool';
  */
 class OvalTool extends paper.Tool {
     static get TOLERANCE () {
-        return 6;
+        return 2;
     }
     /**
      * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
@@ -46,7 +46,7 @@ class OvalTool extends paper.Tool {
             fill: true,
             guide: false,
             match: hitResult =>
-                (hitResult.item.data && hitResult.item.data.isHelperItem) ||
+                (hitResult.item.data && (hitResult.item.data.isScaleHandle || hitResult.item.data.isRotHandle)) ||
                 hitResult.item.selected, // Allow hits on bounding box and selected only
             tolerance: OvalTool.TOLERANCE / paper.view.zoom
         };

--- a/src/helper/tools/rect-tool.js
+++ b/src/helper/tools/rect-tool.js
@@ -10,7 +10,7 @@ import NudgeTool from '../selection-tools/nudge-tool';
  */
 class RectTool extends paper.Tool {
     static get TOLERANCE () {
-        return 6;
+        return 2;
     }
     /**
      * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
@@ -46,7 +46,7 @@ class RectTool extends paper.Tool {
             fill: true,
             guide: false,
             match: hitResult =>
-                (hitResult.item.data && hitResult.item.data.isHelperItem) ||
+                (hitResult.item.data && (hitResult.item.data.isScaleHandle || hitResult.item.data.isRotHandle)) ||
                 hitResult.item.selected, // Allow hits on bounding box and selected only
             tolerance: RectTool.TOLERANCE / paper.view.zoom
         };

--- a/src/helper/tools/text-tool.js
+++ b/src/helper/tools/text-tool.js
@@ -12,7 +12,7 @@ import {getRaster} from '../layer';
  */
 class TextTool extends paper.Tool {
     static get TOLERANCE () {
-        return 6;
+        return 2;
     }
     static get TEXT_EDIT_MODE () {
         return 'TEXT_EDIT_MODE';
@@ -81,7 +81,7 @@ class TextTool extends paper.Tool {
             fill: true,
             guide: false,
             match: hitResult =>
-                (hitResult.item.data && hitResult.item.data.isHelperItem) ||
+                (hitResult.item.data && (hitResult.item.data.isScaleHandle || hitResult.item.data.isRotHandle)) ||
                 hitResult.item.selected, // Allow hits on bounding box and selected only
             tolerance: TextTool.TOLERANCE / paper.view.zoom
         };
@@ -94,7 +94,9 @@ class TextTool extends paper.Tool {
             curves: true,
             fill: true,
             guide: false,
-            match: hitResult => hitResult.item && !hitResult.item.selected, // Unselected only
+            match: hitResult => hitResult.item &&
+                !(hitResult.item.data && hitResult.item.data.isHelperItem) &&
+                !hitResult.item.selected, // Unselected only
             tolerance: TextTool.TOLERANCE / paper.view.zoom
         };
     }


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/144

### Proposed Changes
- Reduce hit tolerances
- Don't allow hits on helper items that aren't handles. This fixes an issue where after clicking on an item, it gets deselected

### Reason for Changes
Hit tolerances are currently too high. If a rectangle this large is drawn:
![image](https://user-images.githubusercontent.com/2855464/43921664-67f86f88-9bea-11e8-82f3-613b97ff293d.png)
then the hit area of the handles is actually double the radius of the visible hit targets:
![image](https://user-images.githubusercontent.com/2855464/43921750-b3d01280-9bea-11e8-9be1-818595fdf87c.png)
making it really difficult to click on the area in the center of the shape in order to move it (you'll probably resize it by mistake.) This resulted when we increased the size of the hit handles, but forgot to decrease the tolerances to match.

If you did manage to hit the center, you would probably deselect the shape instead of being able to move it, which is what the second fix is for.

### Test Coverage
To test:
1. It should now be possible to move small rectangles without reshaping them, as long as you can see a space between the handles in the middle

Things to make sure aren't broken:
1. Handles should still work. At any zoom level, if you are clicking on the handle (the little bubble), then the handle should be selected and draggable.
2. The rotate icon is a handle too. It should not be difficult to use the rotation handle.
3. Check bitmap/vector select tools, as well as reshape tool