### PR TITLE
Mirror margins, borders and arrow icons for RTL

### DIFF
--- a/src/components/color-button/color-button.css
+++ b/src/components/color-button/color-button.css
@@ -12,8 +12,16 @@
     flex-shrink: 0;
     height: 100%;
     border: 1px solid rgba(0, 0, 0, 0.25);
+}
+
+[dir="ltr"] .color-button-swatch {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
+}
+
+[dir="rtl"] .color-button-swatch {
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
 }
 
 .color-button-arrow {
@@ -24,15 +32,24 @@
     flex-shrink: 0;
     height: 100%;
 
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
     border: 1px solid rgba(0, 0, 0, 0.25);
-    border-left: none;
 
     align-items: center;
     justify-content: center;
     color: #575e75;
     font-size: 0.75rem;
+}
+
+[dir="ltr"] .color-button-arrow {
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-left: none;
+}
+
+[dir="rtl"] .color-button-arrow {
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+    border-right: none;
 }
 
 .swatch-icon {

--- a/src/components/dropdown/dropdown.css
+++ b/src/components/dropdown/dropdown.css
@@ -18,9 +18,16 @@ $arrow-border-width: 14px;
 .dropdown-icon {
     width: .5rem;
     height: .5rem;
-    margin-left: .5rem;
     vertical-align: middle;
     padding-bottom: .2rem;
+}
+
+[dir="ltr"] .dropdown-icon {
+    margin-left: .5rem;
+}
+
+[dir="rtl"] .dropdown-icon {
+    margin-right: .5rem;
 }
 
 .mod-caret-up {

--- a/src/components/fixed-tools/fixed-tools.css
+++ b/src/components/fixed-tools/fixed-tools.css
@@ -11,9 +11,14 @@
     width: 8rem;
 }
 
-.mod-dashed-border {
+[dir="ltr"] .mod-dashed-border {
     border-right: 1px dashed $ui-pane-border;
     padding-right: calc(2 * $grid-unit);
+}
+
+[dir="rtl"] .mod-dashed-border {
+    border-left: 1px dashed $ui-pane-border;
+    padding-left: calc(2 * $grid-unit);
 }
 
 .mod-unselect {
@@ -26,33 +31,63 @@ $border-radius: 0.25rem;
     display: inline-block;
     border: 1px solid $ui-pane-border;
     border-radius: 0;
-    border-left: none;
     padding: .35rem;
 }
 
-.button-group-button:last-of-type {
+[dir="ltr"] .button-group-button {
+    border-left: none;
+}
+
+[dir="rtl"] .button-group-button {
+    border-right: none;
+}
+
+[dir="ltr"] .button-group-button:last-of-type {
     border-top-right-radius: $border-radius;
     border-bottom-right-radius: $border-radius;
 }
 
-.button-group-button:first-of-type {
+[dir="ltr"] .button-group-button:first-of-type {
     border-left: 1px solid $ui-pane-border;
     border-top-left-radius: $border-radius;
     border-bottom-left-radius: $border-radius;
 }
 
-.button-group-button.mod-left-border {
+[dir="rtl"] .button-group-button:last-of-type {
+    border-top-left-radius: $border-radius;
+    border-bottom-left-radius: $border-radius;
+}
+
+[dir="rtl"] .button-group-button:first-of-type {
+    border-right: 1px solid $ui-pane-border;
+    border-top-right-radius: $border-radius;
+    border-bottom-right-radius: $border-radius;
+}
+
+[dir="ltr"] .button-group-button.mod-start-border {
     border-left: 1px solid $ui-pane-border;
 }
 
-.button-group-button.mod-no-right-border {
+[dir="rtl"] .button-group-button.mod-start-border {
+    border-right: 1px solid $ui-pane-border;
+}
+
+[dir="ltr"] .button-group-button.mod-no-end-border {
     border-right: none;
+}
+
+[dir="rtl"] .button-group-button.mod-no-end-border {
+    border-left: none;
 }
 
 .button-group-button-icon {
     width: 1.25rem;
     height: 1.25rem;
     vertical-align: middle;
+}
+
+[dir="rtl"] .button-group-button-icon {
+    transform: scaleX(-1);
 }
 
 .mod-context-menu {

--- a/src/components/fixed-tools/fixed-tools.jsx
+++ b/src/components/fixed-tools/fixed-tools.jsx
@@ -121,7 +121,7 @@ const FixedToolsComponent = props => {
                             classNames(
                                 styles.buttonGroupButton,
                                 {
-                                    [styles.modNoRightBorder]: !redoDisabled
+                                    [styles.modNoEndBorder]: !redoDisabled
                                 }
                             )
                         }
@@ -130,7 +130,10 @@ const FixedToolsComponent = props => {
                     >
                         <img
                             alt={props.intl.formatMessage(messages.undo)}
-                            className={styles.buttonGroupButtonIcon}
+                            className={classNames(
+                                styles.buttonGroupButtonIcon,
+                                styles.undoIcon
+                            )}
                             draggable={false}
                             src={undoIcon}
                         />
@@ -140,7 +143,7 @@ const FixedToolsComponent = props => {
                             classNames(
                                 styles.buttonGroupButton,
                                 {
-                                    [styles.modLeftBorder]: !redoDisabled
+                                    [styles.modStartBorder]: !redoDisabled
                                 }
                             )
                         }

--- a/src/components/forms/label.css
+++ b/src/components/forms/label.css
@@ -13,9 +13,16 @@ See https://github.com/LLK/scratch-paint/issues/13 */
 
 .input-label, .input-label-secondary {
     font-size: 0.625rem;
-    margin-right: calc(2 * $grid-unit);
     user-select: none;
     cursor: default;
+}
+
+[dir="ltr"] .input-label, [dir="ltr"] .input-label-secondary{
+    margin-right: calc(2 * $grid-unit);
+}
+
+[dir="rtl"] .input-label, [dir="ltr"] .input-label-secondary{
+    margin-left: calc(2 * $grid-unit);
 }
 
 .input-label {

--- a/src/components/input-group/input-group.css
+++ b/src/components/input-group/input-group.css
@@ -1,7 +1,11 @@
 @import '../../css/units.css';
 
-.input-group + .input-group {
+[dir="ltr"] .input-group + .input-group {
     margin-left: calc(2 * $grid-unit);
+}
+
+[dir="rtl"] .input-group + .input-group {
+    margin-right: calc(2 * $grid-unit);
 }
 
 .disabled {

--- a/src/components/mode-tools/mode-tools.css
+++ b/src/components/mode-tools/mode-tools.css
@@ -13,9 +13,14 @@
     height: 2rem;
 }
 
-.mod-dashed-border {
+[dir="ltr"] .mod-dashed-border {
     border-right: 1px dashed $ui-pane-border;
     padding-right: calc(3 * $grid-unit);
+}
+
+[dir="rtl"] .mod-dashed-border {
+    border-left: 1px dashed $ui-pane-border;
+    padding-left: calc(3 * $grid-unit);
 }
 
 .mod-labeled-icon-height {

--- a/src/components/paint-editor/paint-editor.css
+++ b/src/components/paint-editor/paint-editor.css
@@ -28,11 +28,15 @@
     margin-top: calc(2 * $grid-unit);
 }
 
-.mod-dashed-border {
+[dir="ltr"] .mod-dashed-border {
     border-right: 1px dashed $ui-pane-border;
     padding-right: calc(2 * $grid-unit);
 }
 
+[dir="rtl"] .mod-dashed-border {
+    border-left: 1px dashed $ui-pane-border;
+    padding-left: calc(2 * $grid-unit);
+}
 .mod-labeled-icon-height {
     height: 2.85rem; /* for the second row so the dashed borders are equal in size */
 }
@@ -43,27 +47,53 @@ $border-radius: 0.25rem;
     display: inline-block;
     border: 1px solid $ui-pane-border;
     border-radius: 0;
-    border-left: none;
     padding: .35rem;
 }
 
-.button-group-button:last-of-type {
+[dir="ltr"] .button-group-button {
+    border-left: none;
+}
+
+[dir="rtl"] .button-group-button {
+    border-right: none;
+}
+
+[dir="ltr"] .button-group-button:last-of-type {
     border-top-right-radius: $border-radius;
     border-bottom-right-radius: $border-radius;
 }
 
-.button-group-button:first-of-type {
+[dir="ltr"] .button-group-button:first-of-type {
     border-left: 1px solid $ui-pane-border;
     border-top-left-radius: $border-radius;
     border-bottom-left-radius: $border-radius;
 }
 
-.button-group-button.mod-left-border {
+[dir="rtl"] .button-group-button:last-of-type {
+    border-top-left-radius: $border-radius;
+    border-bottom-left-radius: $border-radius;
+}
+
+[dir="rtl"] .button-group-button:first-of-type {
+    border-right: 1px solid $ui-pane-border;
+    border-top-right-radius: $border-radius;
+    border-bottom-right-radius: $border-radius;
+}
+
+[dir="ltr"] .button-group-button.mod-start-border {
     border-left: 1px solid $ui-pane-border;
 }
 
-.button-group-button.mod-no-right-border {
+[dir="rtl"] .button-group-button.mod-start-border {
+    border-right: 1px solid $ui-pane-border;
+}
+
+[dir="ltr"].button-group-button.mod-no-end-border {
     border-right: none;
+}
+
+[dir="rtl"].button-group-button.mod-no-end-border {
+    border-left: none;
 }
 
 .button-group-button-icon {
@@ -76,8 +106,12 @@ $border-radius: 0.25rem;
     margin-left: calc(2 * $grid-unit);
 }
 
-.mod-margin-right {
+[dir="ltr"] .mod-margin-after {
     margin-right: calc(2 * $grid-unit);
+}
+
+[dir="rtl"] .mod-margin-after {
+    margin-left: calc(2 * $grid-unit);
 }
 
 .canvas-container {
@@ -92,13 +126,20 @@ $border-radius: 0.25rem;
 
 .mode-selector {
     display: flex;
-    margin-right: calc(2 * $grid-unit);
     max-width: 6rem;
     flex-direction: row;
     flex-wrap: wrap;
     align-items: flex-start;
     align-content: flex-start;
     justify-content: space-between;
+}
+
+[dir="ltr"] .mode-selector {
+    margin-right: calc(2 * $grid-unit);
+}
+
+[dir="rtl"] .mode-selector {
+    margin-left: calc(2 * $grid-unit);
 }
 
 .hidden {
@@ -137,8 +178,12 @@ $border-radius: 0.25rem;
     justify-content: center;
 }
 
-.bitmap-button-icon {
+[dir="ltr"] .bitmap-button-icon {
     margin-right: calc(2 * $grid-unit);
+}
+
+[dir="rtl"] .bitmap-button-icon {
+    margin-left: calc(2 * $grid-unit);
 }
 
 @media only screen and (max-width: $full-size-paint) {

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -90,7 +90,7 @@ const PaintEditorComponent = props => (
                         >
                             {/* fill */}
                             <FillColorIndicatorComponent
-                                className={styles.modMarginRight}
+                                className={styles.modMarginAfter}
                                 onUpdateImage={props.onUpdateImage}
                             />
                             {/* stroke */}
@@ -119,7 +119,7 @@ const PaintEditorComponent = props => (
                             >
                                 {/* fill */}
                                 <FillColorIndicatorComponent
-                                    className={styles.modMarginRight}
+                                    className={styles.modMarginAfter}
                                     onUpdateImage={props.onUpdateImage}
                                 />
                             </InputGroup>


### PR DESCRIPTION
I verified that things like the paint brush and magnifying glass should not be mirrored (even people who read Hebrew are usually right-handed)

### Resolves

Resolves #574 

### Proposed Changes

Changes styles based on whether there is a `[dir="rtl"]` or `[dir="ltr"]` on an ancestor of the current style.

Renamed a couple of styles from 'right' and 'left' to 'start' and 'end' so that they continue to make sense in RTL as well as LTR.

### Testing

- [ ] tool layouts should be RTL in Hebrew
- [ ] undo/redo icons should be mirrored in Hebrew
- [ ] other icons (e.g. paint tools) are still right-handed (not mirrored)
- [ ] button borders should have corner radii in the correct places
- [ ] dashed borders between buttons should mirror
- [ ] margins on elements should be mirrored

