### PR TITLE
Scroll containers shouldn't intercept pointer events

### DIFF
--- a/src/components/scrollable-canvas/scrollable-canvas.jsx
+++ b/src/components/scrollable-canvas/scrollable-canvas.jsx
@@ -37,7 +37,7 @@ const ScrollableCanvasComponent = props => (
                 style={{
                     'height': `${props.verticalScrollLengthPercent}%`,
                     'top': `${props.verticalScrollStartPercent}%`,
-                    'pointer-events': 'all',
+                    'pointer-events': 'auto',
                     'display': `${props.hideCursor ||
                         Math.abs(props.verticalScrollLengthPercent - 100) < 1e-8 ? 'none' : 'block'}`
                 }}

--- a/src/components/scrollable-canvas/scrollable-canvas.jsx
+++ b/src/components/scrollable-canvas/scrollable-canvas.jsx
@@ -12,26 +12,34 @@ const ScrollableCanvasComponent = props => (
         )}
     >
         {props.children}
-        <div className={styles.horizontalScrollbarWrapper}>
+        <div
+            className={styles.horizontalScrollbarWrapper}
+            style={{'pointer-events': 'none'}}
+        >
             <div
                 className={styles.horizontalScrollbar}
                 style={{
-                    width: `${props.horizontalScrollLengthPercent}%`,
-                    left: `${props.horizontalScrollStartPercent}%`,
-                    visibility: `${props.hideCursor ||
-                        Math.abs(props.horizontalScrollLengthPercent - 100) < 1e-8 ? 'hidden' : 'visible'}`
+                    'width': `${props.horizontalScrollLengthPercent}%`,
+                    'left': `${props.horizontalScrollStartPercent}%`,
+                    'pointer-events': 'all',
+                    'display': `${props.hideCursor ||
+                        Math.abs(props.horizontalScrollLengthPercent - 100) < 1e-8 ? 'none' : 'block'}`
                 }}
                 onMouseDown={props.onHorizontalScrollbarMouseDown}
             />
         </div>
-        <div className={styles.verticalScrollbarWrapper}>
+        <div
+            className={styles.verticalScrollbarWrapper}
+            style={{'pointer-events': 'none'}}
+        >
             <div
                 className={styles.verticalScrollbar}
                 style={{
-                    height: `${props.verticalScrollLengthPercent}%`,
-                    top: `${props.verticalScrollStartPercent}%`,
-                    visibility: `${props.hideCursor ||
-                        Math.abs(props.verticalScrollLengthPercent - 100) < 1e-8 ? 'hidden' : 'visible'}`
+                    'height': `${props.verticalScrollLengthPercent}%`,
+                    'top': `${props.verticalScrollStartPercent}%`,
+                    'pointer-events': 'all',
+                    'display': `${props.hideCursor ||
+                        Math.abs(props.verticalScrollLengthPercent - 100) < 1e-8 ? 'none' : 'block'}`
                 }}
                 onMouseDown={props.onVerticalScrollbarMouseDown}
             />


### PR DESCRIPTION
### Resolves
Currently, the tool stops working when clicking over where the scroll bars would be when zoomed all the way out

### Proposed Changes
Make the scroll bar containers not take pointer events, so the tool can be used when the scrollbars aren't visible

### Reason for Changes
Odd that tools stopped working near the edges
