### PR TITLE
Fix the pointer-events warning in the console

### DIFF
--- a/src/components/scrollable-canvas/scrollable-canvas.jsx
+++ b/src/components/scrollable-canvas/scrollable-canvas.jsx
@@ -14,15 +14,15 @@ const ScrollableCanvasComponent = props => (
         {props.children}
         <div
             className={styles.horizontalScrollbarWrapper}
-            style={{'pointer-events': 'none'}}
+            style={{pointerEvents: 'none'}}
         >
             <div
                 className={styles.horizontalScrollbar}
                 style={{
-                    'width': `${props.horizontalScrollLengthPercent}%`,
-                    'left': `${props.horizontalScrollStartPercent}%`,
-                    'pointer-events': 'all',
-                    'display': `${props.hideCursor ||
+                    width: `${props.horizontalScrollLengthPercent}%`,
+                    left: `${props.horizontalScrollStartPercent}%`,
+                    pointerEvents: 'auto',
+                    display: `${props.hideCursor ||
                         Math.abs(props.horizontalScrollLengthPercent - 100) < 1e-8 ? 'none' : 'block'}`
                 }}
                 onMouseDown={props.onHorizontalScrollbarMouseDown}
@@ -30,15 +30,15 @@ const ScrollableCanvasComponent = props => (
         </div>
         <div
             className={styles.verticalScrollbarWrapper}
-            style={{'pointer-events': 'none'}}
+            style={{pointerEvents: 'none'}}
         >
             <div
                 className={styles.verticalScrollbar}
                 style={{
-                    'height': `${props.verticalScrollLengthPercent}%`,
-                    'top': `${props.verticalScrollStartPercent}%`,
-                    'pointer-events': 'auto',
-                    'display': `${props.hideCursor ||
+                    height: `${props.verticalScrollLengthPercent}%`,
+                    top: `${props.verticalScrollStartPercent}%`,
+                    pointerEvents: 'auto',
+                    display: `${props.hideCursor ||
                         Math.abs(props.verticalScrollLengthPercent - 100) < 1e-8 ? 'none' : 'block'}`
                 }}
                 onMouseDown={props.onVerticalScrollbarMouseDown}


### PR DESCRIPTION
### Resolves
Console says
warning.js:33 Warning: Unsupported style property pointer-events. Did you mean pointerEvents?
    in div (created by ScrollableCanvasComponent)
    in div (created by ScrollableCanvasComponent)
    in div (created by ScrollableCanvasComponent)
    in ScrollableCanvasComponent (created by ScrollableCanvas)
    in ScrollableCanvas (created by Connect(ScrollableCanvas))
    in Connect(ScrollableCanvas) (created by PaintEditorComponent)
    in div (created by PaintEditorComponent)
    in div (created by PaintEditorComponent)
    in div (created by PaintEditorComponent)
    in PaintEditorComponent (created by InjectIntl(PaintEditorComponent))
    in InjectIntl(PaintEditorComponent) (created by PaintEditor)
    in PaintEditor (created by Connect(PaintEditor))
    in Connect(PaintEditor) (created by CopyPasteWrapper)
    in CopyPasteWrapper (created by Connect(CopyPasteWrapper))
    in Connect(CopyPasteWrapper) (created by SelectionComponent)
    in SelectionComponent (created by Connect(SelectionComponent))
    in Connect(SelectionComponent) (created by Playground)
    in Playground
    in IntlProvider (created by Connect(IntlProvider))
    in Connect(IntlProvider)
    in Provider