### PR TITLE
[WIP] rtl text tool is working if text isn’t rotated

### DIFF
--- a/src/components/paint-editor/paint-editor.css
+++ b/src/components/paint-editor/paint-editor.css
@@ -209,8 +209,8 @@ $border-radius: 0.25rem;
     padding: 0px;
     position: absolute;
     resize: none;
-    -webkit-text-fill-color: transparent;
-    text-fill-color: transparent;
+    /* -webkit-text-fill-color: transparent;
+    text-fill-color: transparent; */
 }
 
 .button-text {

--- a/src/containers/text-mode.jsx
+++ b/src/containers/text-mode.jsx
@@ -95,7 +95,8 @@ class TextMode extends React.Component {
             this.props.onUpdateImage,
             this.props.setTextEditTarget,
             this.props.changeFont,
-            nextProps.isBitmap
+            nextProps.isBitmap,
+            this.props.rtl
         );
         this.tool.setColorState(nextProps.colorState);
         this.tool.setFont(nextProps.font);
@@ -142,6 +143,7 @@ TextMode.propTypes = {
     onChangeFillColor: PropTypes.func.isRequired,
     onChangeStrokeColor: PropTypes.func.isRequired,
     onUpdateImage: PropTypes.func.isRequired,
+    rtl: PropTypes.bool,
     selectedItems: PropTypes.arrayOf(PropTypes.instanceOf(paper.Item)),
     setSelectedItems: PropTypes.func.isRequired,
     setTextEditTarget: PropTypes.func.isRequired,
@@ -156,6 +158,7 @@ const mapStateToProps = (state, ownProps) => ({
     isTextModeActive: ownProps.isBitmap ?
         state.scratchPaint.mode === Modes.BIT_TEXT :
         state.scratchPaint.mode === Modes.TEXT,
+    rtl: state.scratchPaint.layout.rtl,
     selectedItems: state.scratchPaint.selectedItems,
     textEditTarget: state.scratchPaint.textEditTarget,
     viewBounds: state.scratchPaint.viewBounds

--- a/src/playground/playground.jsx
+++ b/src/playground/playground.jsx
@@ -30,12 +30,15 @@ class Playground extends React.Component {
             'handleUpdateName',
             'handleUpdateImage'
         ]);
+        const match = location.search.match(/dir=([^&]+)/);
+        const rtl = match && match[1] == 'rtl';
         this.state = {
             name: 'meow',
             rotationCenterX: 20,
             rotationCenterY: 400,
             imageFormat: 'svg', // 'svg', 'png', or 'jpg'
-            image: svgString // svg string or data URI
+            image: svgString, // svg string or data URI
+            rtl: rtl
         };
     }
     handleUpdateName (name) {


### PR DESCRIPTION
Here's the RTL text tool as far as I got. It's actually working as long as the text isn't rotated. Hope it's helpful.

* Accept `?dir=[ltr|rtl]` parameter on the URL for playground to switch direction

* add setElementTransform to caluculate and set the transform function for the text area element
* call setElementTransform in resizeGuide so it’s called every time the string is updated

* offset transformOrigin by width - seems to help

**Remember, this has the css to hide the text element commented out in order to see where you're typing**