### PR TITLE
Make gradient icons not selectable

### DIFF
--- a/src/components/color-picker/color-picker.css
+++ b/src/components/color-picker/color-picker.css
@@ -98,7 +98,7 @@
     flex-direction: row;
     justify-content: center;
     margin: 8px;
-    user-select: nonr;
+    user-select: none;
 }
 
 [dir="ltr"] .gradient-picker-row > img + img {

--- a/src/components/color-picker/color-picker.css
+++ b/src/components/color-picker/color-picker.css
@@ -98,6 +98,7 @@
     flex-direction: row;
     justify-content: center;
     margin: 8px;
+    user-select: nonr;
 }
 
 [dir="ltr"] .gradient-picker-row > img + img {


### PR DESCRIPTION
### Resolves

Resolves #640

### Proposed Changes

Makes gradient icons not selectable.

### Reason for Changes

Prevents accidentally selecting the icons.