### PR TITLE
Unmount deactivate

### DIFF
--- a/src/components/paint-editor/paint-editor.css
+++ b/src/components/paint-editor/paint-editor.css
@@ -142,10 +142,6 @@ $border-radius: 0.25rem;
     margin-left: calc(2 * $grid-unit);
 }
 
-.hidden {
-    display: none;
-}
-
 .zoom-controls {
     display: flex;
     flex-direction: row-reverse;

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -132,8 +132,8 @@ const PaintEditorComponent = props => (
 
         <div className={styles.topAlignRow}>
             {/* Modes */}
-            {props.canvas !== null ? ( // eslint-disable-line no-negated-condition
-                <div className={isVector(props.format) ? styles.modeSelector : styles.hidden}>
+            {props.canvas !== null && isVector(props.format) ? ( // eslint-disable-line no-negated-condition
+                <div className={styles.modeSelector}>
                     <SelectMode
                         onUpdateImage={props.onUpdateImage}
                     />
@@ -165,8 +165,8 @@ const PaintEditorComponent = props => (
                 </div>
             ) : null}
 
-            {props.canvas !== null ? ( // eslint-disable-line no-negated-condition
-                <div className={isBitmap(props.format) ? styles.modeSelector : styles.hidden}>
+            {props.canvas !== null && isBitmap(props.format) ? ( // eslint-disable-line no-negated-condition
+                <div className={styles.modeSelector}>
                     <BitBrushMode
                         onUpdateImage={props.onUpdateImage}
                     />

--- a/src/containers/bit-brush-mode.jsx
+++ b/src/containers/bit-brush-mode.jsx
@@ -44,6 +44,11 @@ class BitBrushMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isBitBrushModeActive !== this.props.isBitBrushModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         clearSelection(this.props.clearSelectedItems);
         this.props.clearGradient();

--- a/src/containers/bit-eraser-mode.jsx
+++ b/src/containers/bit-eraser-mode.jsx
@@ -38,6 +38,11 @@ class BitEraserMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isBitEraserModeActive !== this.props.isBitEraserModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         clearSelection(this.props.clearSelectedItems);
         this.tool = new BitBrushTool(

--- a/src/containers/bit-fill-mode.jsx
+++ b/src/containers/bit-fill-mode.jsx
@@ -51,6 +51,11 @@ class BitFillMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isFillModeActive !== this.props.isFillModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         clearSelection(this.props.clearSelectedItems);
 

--- a/src/containers/bit-line-mode.jsx
+++ b/src/containers/bit-line-mode.jsx
@@ -44,6 +44,11 @@ class BitLineMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isBitLineModeActive !== this.props.isBitLineModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         clearSelection(this.props.clearSelectedItems);
         this.props.clearGradient();

--- a/src/containers/bit-oval-mode.jsx
+++ b/src/containers/bit-oval-mode.jsx
@@ -53,6 +53,11 @@ class BitOvalMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isOvalModeActive !== this.props.isOvalModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         clearSelection(this.props.clearSelectedItems);
         this.props.clearGradient();

--- a/src/containers/bit-rect-mode.jsx
+++ b/src/containers/bit-rect-mode.jsx
@@ -53,6 +53,11 @@ class BitRectMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isRectModeActive !== this.props.isRectModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         clearSelection(this.props.clearSelectedItems);
         this.props.clearGradient();

--- a/src/containers/bit-select-mode.jsx
+++ b/src/containers/bit-select-mode.jsx
@@ -39,6 +39,11 @@ class BitSelectMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isSelectModeActive !== this.props.isSelectModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         this.props.clearGradient();
         this.tool = new BitSelectTool(

--- a/src/containers/brush-mode.jsx
+++ b/src/containers/brush-mode.jsx
@@ -45,6 +45,11 @@ class BrushMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isBrushModeActive !== this.props.isBrushModeActive;
     }
+    componentWillUnmount () {
+        if (this.blob.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         // TODO: Instead of clearing selection, consider a kind of "draw inside"
         // analogous to how selection works with eraser

--- a/src/containers/eraser-mode.jsx
+++ b/src/containers/eraser-mode.jsx
@@ -39,6 +39,11 @@ class EraserMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isEraserModeActive !== this.props.isEraserModeActive;
     }
+    componentWillUnmount () {
+        if (this.blob.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         this.blob.activateTool({isEraser: true, ...this.props.eraserModeState});
     }

--- a/src/containers/fill-mode.jsx
+++ b/src/containers/fill-mode.jsx
@@ -55,6 +55,11 @@ class FillMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isFillModeActive !== this.props.isFillModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         clearSelection(this.props.clearSelectedItems);
 

--- a/src/containers/line-mode.jsx
+++ b/src/containers/line-mode.jsx
@@ -51,6 +51,11 @@ class LineMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isLineModeActive !== this.props.isLineModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         clearSelection(this.props.clearSelectedItems);
 

--- a/src/containers/oval-mode.jsx
+++ b/src/containers/oval-mode.jsx
@@ -46,6 +46,11 @@ class OvalMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isOvalModeActive !== this.props.isOvalModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         clearSelection(this.props.clearSelectedItems);
         this.props.clearGradient();

--- a/src/containers/rect-mode.jsx
+++ b/src/containers/rect-mode.jsx
@@ -46,6 +46,11 @@ class RectMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isRectModeActive !== this.props.isRectModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         clearSelection(this.props.clearSelectedItems);
         this.props.clearGradient();

--- a/src/containers/reshape-mode.jsx
+++ b/src/containers/reshape-mode.jsx
@@ -39,6 +39,11 @@ class ReshapeMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isReshapeModeActive !== this.props.isReshapeModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         this.tool = new ReshapeTool(
             this.props.setHoveredItem,

--- a/src/containers/rounded-rect-mode.jsx
+++ b/src/containers/rounded-rect-mode.jsx
@@ -39,6 +39,11 @@ class RoundedRectMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isRoundedRectModeActive !== this.props.isRoundedRectModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         this.tool = new RoundedRectTool(
             this.props.setHoveredItem,

--- a/src/containers/select-mode.jsx
+++ b/src/containers/select-mode.jsx
@@ -43,6 +43,11 @@ class SelectMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isSelectModeActive !== this.props.isSelectModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool () {
         this.tool = new SelectTool(
             this.props.setHoveredItem,

--- a/src/containers/text-mode.jsx
+++ b/src/containers/text-mode.jsx
@@ -64,6 +64,11 @@ class TextMode extends React.Component {
     shouldComponentUpdate (nextProps) {
         return nextProps.isTextModeActive !== this.props.isTextModeActive;
     }
+    componentWillUnmount () {
+        if (this.tool) {
+            this.deactivateTool();
+        }
+    }
     activateTool (nextProps) {
         const selected = getSelectedLeafItems();
         let textBoxToStartEditing = null;


### PR DESCRIPTION
### Resolves
This fixes https://github.com/LLK/scratch-paint/issues/595 in some cases

### Proposed Changes
On component unmount, deactivate tools.
This way, if you have uncommitted changes, like a bitmap circle or rectangle, switching tabs will commit the change. (This does not fix committing the shape when changing costumes however)

### Reason for Changes
User does not expect the drawn shape to disappear