### PR TITLE
Handle transparency in bitmap tools

### DIFF
--- a/src/components/color-picker/color-picker.jsx
+++ b/src/components/color-picker/color-picker.jsx
@@ -19,6 +19,7 @@ import fillRadialIcon from './icons/fill-radial-enabled.svg';
 import fillSolidIcon from './icons/fill-solid-enabled.svg';
 import fillVertGradientIcon from './icons/fill-vert-gradient-enabled.svg';
 import swapIcon from './icons/swap.svg';
+import Modes from '../../lib/modes';
 
 const hsvToHex = (h, s, v) =>
     // Scale hue back up to [0, 360] from [0, 100]
@@ -243,7 +244,11 @@ class ColorPickerComponent extends React.Component {
                 </div>
                 <div className={styles.swatchRow}>
                     <div className={styles.swatches}>
-                        <div
+                        {this.props.mode === Modes.BIT_LINE ||
+                            this.props.mode === Modes.BIT_RECT ||
+                            this.props.mode === Modes.BIT_OVAL ||
+                            this.props.mode === Modes.BIT_TEXT ? null :
+                        (<div
                             className={classNames({
                                 [styles.clickable]: true,
                                 [styles.swatch]: true,
@@ -258,7 +263,8 @@ class ColorPickerComponent extends React.Component {
                                 draggable={false}
                                 src={noFillIcon}
                             />
-                        </div>
+                        </div>)
+                        }
                     </div>
                     <div className={styles.swatches}>
                         <div
@@ -291,6 +297,7 @@ ColorPickerComponent.propTypes = {
     hue: PropTypes.number.isRequired,
     intl: intlShape.isRequired,
     isEyeDropping: PropTypes.bool.isRequired,
+    mode: PropTypes.oneOf(Object.keys(Modes)),
     onActivateEyeDropper: PropTypes.func.isRequired,
     onBrightnessChange: PropTypes.func.isRequired,
     onChangeGradientTypeHorizontal: PropTypes.func.isRequired,

--- a/src/components/color-picker/color-picker.jsx
+++ b/src/components/color-picker/color-picker.jsx
@@ -248,22 +248,22 @@ class ColorPickerComponent extends React.Component {
                             this.props.mode === Modes.BIT_RECT ||
                             this.props.mode === Modes.BIT_OVAL ||
                             this.props.mode === Modes.BIT_TEXT ? null :
-                        (<div
-                            className={classNames({
-                                [styles.clickable]: true,
-                                [styles.swatch]: true,
-                                [styles.activeSwatch]:
-                                    (this.props.colorIndex === 0 && this.props.color === null) ||
-                                    (this.props.colorIndex === 1 && this.props.color2 === null)
-                            })}
-                            onClick={this.props.onTransparent}
-                        >
-                            <img
-                                className={styles.swatchIcon}
-                                draggable={false}
-                                src={noFillIcon}
-                            />
-                        </div>)
+                            (<div
+                                className={classNames({
+                                    [styles.clickable]: true,
+                                    [styles.swatch]: true,
+                                    [styles.activeSwatch]:
+                                        (this.props.colorIndex === 0 && this.props.color === null) ||
+                                        (this.props.colorIndex === 1 && this.props.color2 === null)
+                                })}
+                                onClick={this.props.onTransparent}
+                            >
+                                <img
+                                    className={styles.swatchIcon}
+                                    draggable={false}
+                                    src={noFillIcon}
+                                />
+                            </div>)
                         }
                     </div>
                     <div className={styles.swatches}>

--- a/src/containers/color-picker.jsx
+++ b/src/containers/color-picker.jsx
@@ -12,6 +12,7 @@ import GradientTypes from '../lib/gradient-types';
 
 import ColorPickerComponent from '../components/color-picker/color-picker.jsx';
 import {MIXED} from '../helper/style-path';
+import Modes from '../lib/modes';
 
 const colorStringToHsv = hexString => {
     const hsv = parseColor(hexString).hsv;
@@ -129,6 +130,7 @@ class ColorPicker extends React.Component {
                 gradientType={this.props.gradientType}
                 hue={this.state.hue}
                 isEyeDropping={this.props.isEyeDropping}
+                mode={this.props.mode}
                 rtl={this.props.rtl}
                 saturation={this.state.saturation}
                 shouldShowGradientTools={this.props.shouldShowGradientTools}
@@ -155,6 +157,7 @@ ColorPicker.propTypes = {
     colorIndex: PropTypes.number.isRequired,
     gradientType: PropTypes.oneOf(Object.keys(GradientTypes)).isRequired,
     isEyeDropping: PropTypes.bool.isRequired,
+    mode: PropTypes.oneOf(Object.keys(Modes)),
     onActivateEyeDropper: PropTypes.func.isRequired,
     onChangeColor: PropTypes.func.isRequired,
     onChangeGradientType: PropTypes.func,
@@ -168,6 +171,7 @@ ColorPicker.propTypes = {
 const mapStateToProps = state => ({
     colorIndex: state.scratchPaint.fillMode.colorIndex,
     isEyeDropping: state.scratchPaint.color.eyeDropper.active,
+    mode: state.scratchPaint.mode,
     rtl: state.scratchPaint.layout.rtl
 });
 

--- a/src/containers/text-mode.jsx
+++ b/src/containers/text-mode.jsx
@@ -78,7 +78,7 @@ class TextMode extends React.Component {
         // This way the tool won't draw an invisible state, or be unclear about what will be drawn.
         const {fillColor, strokeColor, strokeWidth} = nextProps.colorState;
         const fillColorPresent = fillColor !== MIXED && fillColor !== null;
-        const strokeColorPresent =
+        const strokeColorPresent = nextProps.isBitmap ? false :
             strokeColor !== MIXED && strokeColor !== null && strokeWidth !== null && strokeWidth !== 0;
         if (!fillColorPresent && !strokeColorPresent) {
             this.props.onChangeFillColor(DEFAULT_COLOR);

--- a/src/helper/bit-tools/brush-tool.js
+++ b/src/helper/bit-tools/brush-tool.js
@@ -15,7 +15,7 @@ class BrushTool extends paper.Tool {
         super();
         this.onUpdateImage = onUpdateImage;
         this.isEraser = isEraser;
-        
+
         // We have to set these functions instead of just declaring them because
         // paper.js tools hook up the listeners in the setter functions.
         this.onMouseMove = this.handleMouseMove;
@@ -30,22 +30,22 @@ class BrushTool extends paper.Tool {
     }
     setColor (color) {
         this.color = color;
-        this.tmpCanvas = getBrushMark(this.size, this.color, this.isEraser);
+        this.tmpCanvas = getBrushMark(this.size, this.color, this.isEraser || !this.color);
     }
     setBrushSize (size) {
         // For performance, make sure this is an integer
         this.size = Math.max(1, ~~size);
-        this.tmpCanvas = getBrushMark(this.size, this.color, this.isEraser);
+        this.tmpCanvas = getBrushMark(this.size, this.color, this.isEraser || !this.color);
     }
     // Draw a brush mark at the given point
     draw (x, y) {
         const roundedUpRadius = Math.ceil(this.size / 2);
         const context = getRaster().getContext('2d');
-        if (this.isEraser) {
+        if (this.isEraser || !this.color) {
             context.globalCompositeOperation = 'destination-out';
         }
         getRaster().drawImage(this.tmpCanvas, new paper.Point(~~x - roundedUpRadius, ~~y - roundedUpRadius));
-        if (this.isEraser) {
+        if (this.isEraser || !this.color) {
             context.globalCompositeOperation = 'source-over';
         }
     }
@@ -65,7 +65,7 @@ class BrushTool extends paper.Tool {
                 this.cursorPreview.remove();
             }
 
-            this.tmpCanvas = getBrushMark(this.size, this.color, this.isEraser);
+            this.tmpCanvas = getBrushMark(this.size, this.color, this.isEraser || !this.color);
             this.cursorPreview = new paper.Raster(this.tmpCanvas);
             this.cursorPreview.guide = true;
             this.cursorPreview.parent = getGuideLayer();
@@ -82,7 +82,7 @@ class BrushTool extends paper.Tool {
     handleMouseDown (event) {
         if (event.event.button > 0) return; // only first mouse button
         this.active = true;
-        
+
         if (this.cursorPreview) {
             this.cursorPreview.remove();
         }
@@ -98,7 +98,7 @@ class BrushTool extends paper.Tool {
     }
     handleMouseUp (event) {
         if (event.event.button > 0 || !this.active) return; // only first mouse button
-        
+
         forEachLinePoint(this.lastPoint, event.point, this.draw.bind(this));
         this.onUpdateImage();
 


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/535
Fixing this as a prereq for https://github.com/LLK/scratch-paint/pull/662

### Proposed Changes
Take out the option to have transparent fill in line, rect, oval, and text tools in bitmap. Make transparent brush act like eraser.

### Reason for Changes
Transparency in these tools was not supported in scratch 2 and the behavior is weird right now.

### Test Coverage
Test that you can't get into the transparent color in those 4 tools in bitmap mode.
Test that the bitmap brush works and acts like an eraser when set to transparent.