### PR TITLE
Export bit shapes

### DIFF
--- a/src/helper/bit-tools/oval-tool.js
+++ b/src/helper/bit-tools/oval-tool.js
@@ -85,7 +85,7 @@ class OvalTool extends paper.Tool {
         if (this.oval) {
             if (this.filled) {
                 this.oval.fillColor = this.color;
-                this.oval.strokeWidh = 0;
+                this.oval.strokeWidth = 0;
                 this.oval.strokeColor = null;
             } else {
                 this.oval.fillColor = null;

--- a/src/helper/bit-tools/oval-tool.js
+++ b/src/helper/bit-tools/oval-tool.js
@@ -1,6 +1,6 @@
 import paper from '@scratch/paper';
 import Modes from '../../lib/modes';
-import {drawEllipse} from '../bitmap';
+import {commitOvalToBitmap} from '../bitmap';
 import {getRaster} from '../layer';
 import {clearSelection} from '../selection';
 import BoundingBoxTool from '../selection-tools/bounding-box-tool';
@@ -176,29 +176,14 @@ class OvalTool extends paper.Tool {
             }
         }
         this.active = false;
+        this.onUpdateImage();
     }
     commitOval () {
         if (!this.oval || !this.oval.isInserted()) return;
 
-        const radiusX = Math.abs(this.oval.size.width / 2);
-        const radiusY = Math.abs(this.oval.size.height / 2);
-        const context = getRaster().getContext('2d');
-        context.fillStyle = this.color;
-
-        const drew = drawEllipse({
-            position: this.oval.position,
-            radiusX,
-            radiusY,
-            matrix: this.oval.matrix,
-            isFilled: this.filled,
-            thickness: this.thickness / paper.view.zoom
-        }, context);
-
+        commitOvalToBitmap(this.oval, getRaster());
         this.oval.remove();
         this.oval = null;
-        if (drew) {
-            this.onUpdateImage();
-        }
     }
     deactivateTool () {
         this.commitOval();

--- a/src/helper/bit-tools/rect-tool.js
+++ b/src/helper/bit-tools/rect-tool.js
@@ -85,7 +85,7 @@ class RectTool extends paper.Tool {
         if (this.rect) {
             if (this.filled) {
                 this.rect.fillColor = this.color;
-                this.rect.strokeWidh = 0;
+                this.rect.strokeWidth = 0;
                 this.rect.strokeColor = null;
             } else {
                 this.rect.fillColor = null;

--- a/src/helper/bit-tools/rect-tool.js
+++ b/src/helper/bit-tools/rect-tool.js
@@ -1,7 +1,7 @@
 import paper from '@scratch/paper';
 import Modes from '../../lib/modes';
-import {fillRect, outlineRect} from '../bitmap';
-import {createCanvas, getRaster} from '../layer';
+import {commitRectToBitmap} from '../bitmap';
+import {getRaster} from '../layer';
 import {clearSelection} from '../selection';
 import BoundingBoxTool from '../selection-tools/bounding-box-tool';
 import NudgeTool from '../selection-tools/nudge-tool';
@@ -169,23 +169,15 @@ class RectTool extends paper.Tool {
             }
         }
         this.active = false;
+        this.onUpdateImage();
     }
     commitRect () {
         if (!this.rect || !this.rect.isInserted()) return;
 
-        const tmpCanvas = createCanvas();
-        const context = tmpCanvas.getContext('2d');
-        context.fillStyle = this.color;
-        if (this.filled) {
-            fillRect(this.rect, context);
-        } else {
-            outlineRect(this.rect, this.thickness / paper.view.zoom, context);
-        }
-        getRaster().drawImage(tmpCanvas, new paper.Point());
-
+        commitRectToBitmap(this.rect, getRaster());
+        
         this.rect.remove();
         this.rect = null;
-        this.onUpdateImage();
     }
     deactivateTool () {
         this.commitRect();

--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -737,6 +737,47 @@ const commitSelectionToBitmap = function (selection, bitmap) {
     commitArbitraryTransformation_(selection, bitmap);
 };
 
+/**
+ * @param {paper.Shape.Ellipse} oval Vector oval to convert
+ * @param {paper.Raster} bitmap raster to draw selection
+ * @return {bool} true if the oval was drawn
+ */
+const commitOvalToBitmap = function (oval, bitmap) {
+    const radiusX = Math.abs(oval.size.width / 2);
+    const radiusY = Math.abs(oval.size.height / 2);
+    const context = bitmap.getContext('2d');
+    const filled = oval.strokeWidth === 0;
+    context.fillStyle = filled ? oval.fillColor.toCSS() : oval.strokeColor.toCSS();
+
+    const drew = drawEllipse({
+        position: oval.position,
+        radiusX,
+        radiusY,
+        matrix: oval.matrix,
+        isFilled: filled,
+        thickness: oval.strokeWidth / paper.view.zoom
+    }, context);
+
+    return drew;
+};
+
+/**
+ * @param {paper.Rectangle} rect Vector rectangle to convert
+ * @param {paper.Raster} bitmap raster to draw selection to
+ */
+const commitRectToBitmap = function (rect, bitmap) {
+    const tmpCanvas = createCanvas();
+    const context = tmpCanvas.getContext('2d');
+    const filled = rect.strokeWidth === 0;
+    context.fillStyle = filled ? rect.fillColor.toCSS() : rect.strokeColor.toCSS();
+    if (filled) {
+        fillRect(rect, context);
+    } else {
+        outlineRect(rect, rect.strokeWidth / paper.view.zoom, context);
+    }
+    bitmap.drawImage(tmpCanvas, new paper.Point());
+};
+
 const selectAllBitmap = function (clearSelectedItems) {
     clearSelection(clearSelectedItems);
 
@@ -752,6 +793,8 @@ const selectAllBitmap = function (clearSelectedItems) {
 
 export {
     commitSelectionToBitmap,
+    commitOvalToBitmap,
+    commitRectToBitmap,
     convertToBitmap,
     convertToVector,
     fillRect,

--- a/src/hocs/update-image-hoc.jsx
+++ b/src/hocs/update-image-hoc.jsx
@@ -11,7 +11,7 @@ import {setSelectedItems} from '../reducers/selected-items';
 
 import {getSelectedLeafItems} from '../helper/selection';
 import {getRaster, hideGuideLayers, showGuideLayers} from '../helper/layer';
-import {commitSelectionToBitmap, getHitBounds} from '../helper/bitmap';
+import {commitRectToBitmap, commitOvalToBitmap, commitSelectionToBitmap, getHitBounds} from '../helper/bitmap';
 import {performSnapshot} from '../helper/undo';
 import {scaleWithStrokes} from '../helper/math';
 import {ART_BOARD_WIDTH, ART_BOARD_HEIGHT, SVG_ART_BOARD_WIDTH, SVG_ART_BOARD_HEIGHT} from '../helper/view';
@@ -57,21 +57,29 @@ const UpdateImageHOC = function (WrappedComponent) {
                 log.warn('Bitmap layer should be loaded before calling updateImage.');
                 return;
             }
+            // Anything that is selected is on the vector layer waiting to be committed to the bitmap layer.
             // Plaster the selection onto the raster layer before exporting, if there is a selection.
             const plasteredRaster = getRaster().getSubRaster(getRaster().bounds);
             plasteredRaster.remove(); // Don't insert
             const selectedItems = getSelectedLeafItems();
-            if (selectedItems.length === 1 && selectedItems[0] instanceof paper.Raster) {
-                if (!selectedItems[0].loaded ||
-                    (selectedItems[0].data &&
-                        selectedItems[0].data.expanded &&
-                        !selectedItems[0].data.expanded.loaded)) {
-                    // This may get logged when rapidly undoing/redoing or changing costumes,
-                    // in which case the warning is not relevant.
-                    log.warn('Bitmap layer should be loaded before calling updateImage.');
-                    return;
+            if (selectedItems.length === 1) {
+                const item = selectedItems[0];
+                if (item instanceof paper.Raster) {
+                    if (!item.loaded ||
+                        (item.data &&
+                            item.data.expanded &&
+                            !item.data.expanded.loaded)) {
+                        // This may get logged when rapidly undoing/redoing or changing costumes,
+                        // in which case the warning is not relevant.
+                        log.warn('Bitmap layer should be loaded before calling updateImage.');
+                        return;
+                    }
+                    commitSelectionToBitmap(item, plasteredRaster);
+                } else if (item instanceof paper.Shape && item.type === 'rectangle') {
+                    commitRectToBitmap(item, plasteredRaster);
+                } else if (item instanceof paper.Shape && item.type === 'ellipse') {
+                    commitOvalToBitmap(item, plasteredRaster);
                 }
-                commitSelectionToBitmap(selectedItems[0], plasteredRaster);
             }
             const rect = getHitBounds(plasteredRaster);
             this.props.onUpdateImage(


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/595
Depends on https://github.com/LLK/scratch-paint/pull/660 going in first

### Proposed Changes
Like we did for the select tool, oval and rect tool temporary state is exported with bitmaps. This way, they don't disappear if you leave the paint editor before they are committed.

### Reason for Changes
Shapes unexpectedly disappear
