### PR TITLE
Fence tools to make it less easy to lose work off the sides

### DIFF
--- a/src/helper/selection-tools/move-tool.js
+++ b/src/helper/selection-tools/move-tool.js
@@ -99,12 +99,10 @@ class MoveTool {
     }
     onMouseDrag (event) {
         const point = event.point;
-        if (event.point.x > ART_BOARD_WIDTH || event.point.y > ART_BOARD_HEIGHT ||
-                event.point.x < 0 || event.point.y < 0) {
-            point.x = Math.max(0, Math.min(point.x, ART_BOARD_WIDTH));
-            point.y = Math.max(0, Math.min(point.y, ART_BOARD_HEIGHT));
-        }
+        point.x = Math.max(0, Math.min(point.x, ART_BOARD_WIDTH));
+        point.y = Math.max(0, Math.min(point.y, ART_BOARD_HEIGHT));
         const dragVector = point.subtract(event.downPoint);
+
         for (const item of this.selectedItems) {
             // add the position of the item before the drag started
             // for later use in the snap calculation

--- a/src/helper/selection-tools/move-tool.js
+++ b/src/helper/selection-tools/move-tool.js
@@ -3,6 +3,7 @@ import Modes from '../../lib/modes';
 import {isGroup} from '../group';
 import {isCompoundPathItem, getRootItem} from '../item';
 import {snapDeltaToAngle} from '../math';
+import {ART_BOARD_WIDTH, ART_BOARD_HEIGHT} from '../view';
 import {clearSelection, cloneSelection, getSelectedLeafItems, getSelectedRootItems, setItemSelection}
     from '../selection';
 
@@ -97,7 +98,13 @@ class MoveTool {
         this.setSelectedItems();
     }
     onMouseDrag (event) {
-        const dragVector = event.point.subtract(event.downPoint);
+        const point = event.point;
+        if (event.point.x > ART_BOARD_WIDTH || event.point.y > ART_BOARD_HEIGHT ||
+                event.point.x < 0 || event.point.y < 0) {
+            point.x = Math.max(0, Math.min(point.x, ART_BOARD_WIDTH));
+            point.y = Math.max(0, Math.min(point.y, ART_BOARD_HEIGHT));
+        }
+        const dragVector = point.subtract(event.downPoint);
         for (const item of this.selectedItems) {
             // add the position of the item before the drag started
             // for later use in the snap calculation

--- a/src/helper/selection-tools/nudge-tool.js
+++ b/src/helper/selection-tools/nudge-tool.js
@@ -50,7 +50,6 @@ class NudgeTool {
             translation = new paper.Point(Math.min(nudgeAmount, ART_BOARD_WIDTH - rect.left - 1), 0);
         }
 
-
         if (translation) {
             for (const item of selected) {
                 item.translate(translation);

--- a/src/helper/selection-tools/nudge-tool.js
+++ b/src/helper/selection-tools/nudge-tool.js
@@ -1,5 +1,8 @@
-import {getSelectedRootItems} from '../selection';
 import paper from '@scratch/paper';
+import {getSelectedRootItems} from '../selection';
+import {ART_BOARD_WIDTH, ART_BOARD_HEIGHT} from '../view';
+
+const NUDGE_MORE_MULTIPLIER = 15;
 
 /**
  * Tool containing handlers for arrow key events for nudging the selection.
@@ -20,26 +23,40 @@ class NudgeTool {
             return;
         }
 
-        const nudgeAmount = 1 / paper.view.zoom;
+        let nudgeAmount = 1 / paper.view.zoom;
+        if (event.modifiers.shift) nudgeAmount *= NUDGE_MORE_MULTIPLIER;
+
         const selected = getSelectedRootItems();
         if (selected.length === 0) return;
+        
+        // Get bounds. Don't let item bounds go out of bounds.
+        let rect;
+        for (const item of selected) {
+            if (rect) {
+                rect = rect.unite(item.bounds);
+            } else {
+                rect = item.bounds;
+            }
+        }
 
         let translation;
         if (event.key === 'up') {
-            translation = new paper.Point(0, -nudgeAmount);
+            translation = new paper.Point(0, -Math.min(nudgeAmount, rect.bottom - 1));
         } else if (event.key === 'down') {
-            translation = new paper.Point(0, nudgeAmount);
+            translation = new paper.Point(0, Math.min(nudgeAmount, ART_BOARD_HEIGHT - rect.top - 1));
         } else if (event.key === 'left') {
-            translation = new paper.Point(-nudgeAmount, 0);
+            translation = new paper.Point(-Math.min(nudgeAmount, rect.right - 1), 0);
         } else if (event.key === 'right') {
-            translation = new paper.Point(nudgeAmount, 0);
+            translation = new paper.Point(Math.min(nudgeAmount, ART_BOARD_WIDTH - rect.left - 1), 0);
         }
+
 
         if (translation) {
             for (const item of selected) {
                 item.translate(translation);
             }
             this.boundingBoxTool.setSelectionBounds();
+            event.preventDefault();
         }
     }
     onKeyUp (event) {

--- a/src/helper/selection-tools/point-tool.js
+++ b/src/helper/selection-tools/point-tool.js
@@ -146,11 +146,9 @@ class PointTool {
         this.deleteOnMouseUp = null;
         
         const point = event.point;
-        if (event.point.x > ART_BOARD_WIDTH || event.point.y > ART_BOARD_HEIGHT ||
-                event.point.x < 0 || event.point.y < 0) {
-            point.x = Math.max(0, Math.min(point.x, ART_BOARD_WIDTH));
-            point.y = Math.max(0, Math.min(point.y, ART_BOARD_HEIGHT));
-        }
+        point.x = Math.max(0, Math.min(point.x, ART_BOARD_WIDTH));
+        point.y = Math.max(0, Math.min(point.y, ART_BOARD_HEIGHT));
+
         if (!this.lastPoint) this.lastPoint = event.lastPoint;
         const dragVector = point.subtract(event.downPoint);
         const delta = point.subtract(this.lastPoint);

--- a/src/helper/selection-tools/scale-tool.js
+++ b/src/helper/selection-tools/scale-tool.js
@@ -69,11 +69,9 @@ class ScaleTool {
     onMouseDrag (event) {
         if (!this.active) return;
         const point = event.point;
-        if (event.point.x > ART_BOARD_WIDTH || event.point.y > ART_BOARD_HEIGHT ||
-                event.point.x < 0 || event.point.y < 0) {
-            point.x = Math.max(0, Math.min(point.x, ART_BOARD_WIDTH));
-            point.y = Math.max(0, Math.min(point.y, ART_BOARD_HEIGHT));
-        }
+        point.x = Math.max(0, Math.min(point.x, ART_BOARD_WIDTH));
+        point.y = Math.max(0, Math.min(point.y, ART_BOARD_HEIGHT));
+
         if (!this.lastPoint) this.lastPoint = event.lastPoint;
         const delta = point.subtract(this.lastPoint);
         this.lastPoint = point;

--- a/src/helper/selection-tools/scale-tool.js
+++ b/src/helper/selection-tools/scale-tool.js
@@ -1,5 +1,6 @@
 import paper from '@scratch/paper';
 import {getItems} from '../selection';
+import {ART_BOARD_WIDTH, ART_BOARD_HEIGHT} from '../view';
 
 /**
  * Tool to handle scaling items by pulling on the handles around the edges of the bounding
@@ -20,6 +21,7 @@ class ScaleTool {
         this.itemGroup = null;
         // Lowest item above all scale items in z index
         this.itemToInsertBelow = null;
+        this.lastPoint = null;
         this.onUpdateImage = onUpdateImage;
     }
 
@@ -66,6 +68,15 @@ class ScaleTool {
     }
     onMouseDrag (event) {
         if (!this.active) return;
+        const point = event.point;
+        if (event.point.x > ART_BOARD_WIDTH || event.point.y > ART_BOARD_HEIGHT ||
+                event.point.x < 0 || event.point.y < 0) {
+            point.x = Math.max(0, Math.min(point.x, ART_BOARD_WIDTH));
+            point.y = Math.max(0, Math.min(point.y, ART_BOARD_HEIGHT));
+        }
+        if (!this.lastPoint) this.lastPoint = event.lastPoint;
+        const delta = point.subtract(this.lastPoint);
+        this.lastPoint = point;
 
         const modOrigSize = this.origSize;
 
@@ -85,7 +96,7 @@ class ScaleTool {
             this.pivot = this.origPivot;
         }
 
-        this.corner = this.corner.add(event.delta);
+        this.corner = this.corner.add(delta);
         const size = this.corner.subtract(this.pivot);
         let sx = 1.0;
         let sy = 1.0;
@@ -109,6 +120,7 @@ class ScaleTool {
     }
     onMouseUp () {
         if (!this.active) return;
+        this.lastPoint = null;
 
         this.pivot = null;
         this.origPivot = null;


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/166

### Proposed Changes
Fence the move, move point (reshape), nudge, and scale tools to the canvas area.
This also adds super-nudge

### Reason for Changes
Currently, it's easy to move shapes off the edges of the paint editor, which then become inaccessible but are still visible in the thumbnail and on stage, which can be confusing. These changes don't completely prevent moving items off the edges, but make it a more difficult state for beginners to get into.

### Testing
Try moving shapes off the paint editor bounds in the various tools in which you can move things, such as select, reshape, and shape tools, in bitmap and vector. Super-nudge is shift+arrow keys.