### PR TITLE
Use RGBA instead of hex so Edge can understand the color

### DIFF
--- a/src/components/scrollable-canvas/scrollable-canvas.css
+++ b/src/components/scrollable-canvas/scrollable-canvas.css
@@ -3,7 +3,7 @@ $scrollbar-padding: 1px;
 
 .vertical-scrollbar, .horizontal-scrollbar {
     position: absolute;
-    background: #BEBEBECD;
+    background: rgba(190, 190, 190, 0.8);
     border-radius: 3px;
     cursor: pointer;
 }


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/612

### Proposed Changes
Make scrollbars visible in Edge

### Reason for Changes
Edge can't understand 8 character hex colors