### PR TITLE
Don't navigate away when paint editor is open and delete/backspace are pressed

### DIFF
--- a/src/hocs/keyboard-shortcuts-hoc.jsx
+++ b/src/hocs/keyboard-shortcuts-hoc.jsx
@@ -38,6 +38,7 @@ const KeyboardShortcutsHOC = function (WrappedComponent) {
                 event.preventDefault();
                 clearSelection(this.props.clearSelectedItems);
             } else if (event.key === 'Delete' || event.key === 'Backspace') {
+                event.preventDefault();
                 if (deleteSelection(this.props.mode, this.props.onUpdateImage)) {
                     this.props.setSelectedItems(this.props.format);
                 }


### PR DESCRIPTION
### Resolves
https://github.com/LLK/scratch-paint/issues/663

### Proposed Changes
Capture backspace and delete key actions when in the paint editor (so Firefox won't try to navigate away from the page)

### Reason for Changes
Delete is a shortcut in Paint and it's frustrating that a pop-up comes up every time, or if you accidentally navigate away from the page.