### PR TITLE
Export bit text

### DIFF
--- a/src/hocs/update-image-hoc.jsx
+++ b/src/hocs/update-image-hoc.jsx
@@ -79,6 +79,12 @@ const UpdateImageHOC = function (WrappedComponent) {
                     commitRectToBitmap(item, plasteredRaster);
                 } else if (item instanceof paper.Shape && item.type === 'ellipse') {
                     commitOvalToBitmap(item, plasteredRaster);
+                } else if (item instanceof paper.PointText) {
+                    const textRaster = item.rasterize(72, false /* insert */);
+                    plasteredRaster.drawImage(
+                        textRaster.canvas,
+                        new paper.Point(Math.floor(textRaster.bounds.x), Math.floor(textRaster.bounds.y))
+                    );
                 }
             }
             const rect = getHitBounds(plasteredRaster);


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/675

### Proposed Changes
Export bitmapified text if there is text being edited when switching costumes

### Reason for Changes
Don't lose bitmap text if you change costumes in the middle of editing text
