### PR TITLE
Add safety checks to fill and stroke colors

### DIFF
--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -747,7 +747,8 @@ const commitOvalToBitmap = function (oval, bitmap) {
     const radiusY = Math.abs(oval.size.height / 2);
     const context = bitmap.getContext('2d');
     const filled = oval.strokeWidth === 0;
-    context.fillStyle = filled ? oval.fillColor.toCSS() : oval.strokeColor.toCSS();
+    context.fillStyle = filled ?
+        oval.fillColor && oval.fillColor.toCSS() : oval.strokeColor && oval.strokeColor.toCSS();
 
     const drew = drawEllipse({
         position: oval.position,
@@ -769,7 +770,8 @@ const commitRectToBitmap = function (rect, bitmap) {
     const tmpCanvas = createCanvas();
     const context = tmpCanvas.getContext('2d');
     const filled = rect.strokeWidth === 0;
-    context.fillStyle = filled ? rect.fillColor.toCSS() : rect.strokeColor.toCSS();
+    context.fillStyle = filled ?
+        rect.fillColor && rect.fillColor.toCSS() : rect.strokeColor && rect.strokeColor.toCSS();
     if (filled) {
         fillRect(rect, context);
     } else {


### PR DESCRIPTION
### Resolves
Fixes issue found in smoke test:
In Bitmap while drawing a square or circle and using the eyedropper to pick transparency from the backdrop crashes the paint editor.

### Proposed Changes
Perform a safety check before calling toCSS on fill and stroke colors. This reverts the behavior to the behavior on beta, where a transparent object is drawn, and when you click off of it it becomes black.

### Reason for Changes
Fix crash

### Test Coverage
Tested drawing transparent and non-transparent filled/outlined circles and ovals on Windows 10 Chrome, Firefox, and Edge