### PR TITLE
Don't scale text outlines

### DIFF
--- a/src/helper/math.js
+++ b/src/helper/math.js
@@ -120,6 +120,10 @@ const ensureClockwise = function (root) {
 // Scale item and its strokes by factor
 const scaleWithStrokes = function (root, factor, pivot) {
     _doRecursively(root, item => {
+        if (item instanceof paper.PointText) {
+            // Text outline size is controlled by text transform matrix, thus it's already scaled.
+            return;
+        }
         if (item.strokeWidth) {
             item.strokeWidth = item.strokeWidth * factor;
         }


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/465

### Proposed Changes
Unlike for other shapes, text outline thickness changes with its scale. Since the scale already captures the outline thickness change, there's no need to re-double it in scaleWithStrokes

### Testing
Test loading text with outlines and adjusting text with outlines. The paint editor and stage should match.