### PR TITLE
Use consistent hit testing

### DIFF
--- a/src/helper/hover.js
+++ b/src/helper/hover.js
@@ -30,6 +30,7 @@ const getHoveredItem = function (event, hitOptions, subselect) {
         }
     }
     const item = hitResult.item;
+    // If the hovered item is already selected, then there should be no hovered item.
     if (!item || item.selected) {
         return null;
     }

--- a/src/helper/hover.js
+++ b/src/helper/hover.js
@@ -2,7 +2,7 @@ import paper from '@scratch/paper';
 import {isBoundsItem, getRootItem} from './item';
 import {hoverBounds, hoverItem} from './guides';
 import {isGroupChild} from './group';
-import {sortHitResultsByZIndex} from './math';
+import {sortItemsByZIndex} from './math';
 
 /**
  * @param {!MouseEvent} event mouse event
@@ -25,7 +25,7 @@ const getHoveredItem = function (event, hitOptions, subselect) {
     // Get highest z-index result
     let hitResult;
     for (const result of hitResults) {
-        if (!hitResult || sortHitResultsByZIndex(hitResult, result) < 0) {
+        if (!hitResult || sortItemsByZIndex(hitResult.item, result.item) < 0) {
             hitResult = result;
         }
     }

--- a/src/helper/hover.js
+++ b/src/helper/hover.js
@@ -20,14 +20,14 @@ const getHoveredItem = function (event, hitOptions, subselect) {
     // sort items by z-index
     const items = [];
     for (const hitResult of hitResults) {
-        if (!(hitResult.item.data && hitResult.item.data.noHover) && !hitResult.item.selected) {
+        if (!(hitResult.item.data && hitResult.item.data.noHover)) {
             items.push(hitResult.item);
         }
     }
     items.sort(sortItemsByZIndex);
 
     const item = items[items.length - 1];
-    if (!item) {
+    if (!item || item.selected) {
         return null;
     }
 

--- a/src/helper/hover.js
+++ b/src/helper/hover.js
@@ -2,7 +2,7 @@ import paper from '@scratch/paper';
 import {isBoundsItem, getRootItem} from './item';
 import {hoverBounds, hoverItem} from './guides';
 import {isGroupChild} from './group';
-import {sortItemsByZIndex} from './math';
+import {sortHitResultsByZIndex} from './math';
 
 /**
  * @param {!MouseEvent} event mouse event
@@ -12,21 +12,24 @@ import {sortItemsByZIndex} from './math';
  * @return {paper.Item} the hovered item or null if there is none
  */
 const getHoveredItem = function (event, hitOptions, subselect) {
-    // @todo make hit test only hit painting layer
+    const oldMatch = hitOptions.match;
+    hitOptions.match = hitResult => {
+        if (hitResult.item.data && hitResult.item.data.noHover) return false;
+        return oldMatch ? oldMatch(hitResult) : true;
+    };
     const hitResults = paper.project.hitTestAll(event.point, hitOptions);
     if (hitResults.length === 0) {
         return null;
     }
-    // sort items by z-index
-    const items = [];
-    for (const hitResult of hitResults) {
-        if (!(hitResult.item.data && hitResult.item.data.noHover)) {
-            items.push(hitResult.item);
+
+    // Get highest z-index result
+    let hitResult;
+    for (const result of hitResults) {
+        if (!hitResult || sortHitResultsByZIndex(hitResult, result) < 0) {
+            hitResult = result;
         }
     }
-    items.sort(sortItemsByZIndex);
-
-    const item = items[items.length - 1];
+    const item = hitResult.item;
     if (!item || item.selected) {
         return null;
     }

--- a/src/helper/math.js
+++ b/src/helper/math.js
@@ -44,6 +44,10 @@ const _getDepth = function (item) {
     return depth;
 };
 
+const sortHitResultsByZIndex = function (a, b) {
+    return sortItemsByZIndex(a.item, b.item);
+};
+
 const sortItemsByZIndex = function (a, b) {
     if (a === null || b === null) {
         return null;
@@ -136,5 +140,6 @@ export {
     getRandomBoolean,
     scaleWithStrokes,
     snapDeltaToAngle,
-    sortItemsByZIndex
+    sortItemsByZIndex,
+    sortHitResultsByZIndex
 };

--- a/src/helper/math.js
+++ b/src/helper/math.js
@@ -82,10 +82,6 @@ const sortItemsByZIndex = function (a, b) {
     return null;
 };
 
-const sortHitResultsByZIndex = function (a, b) {
-    return sortItemsByZIndex(a.item, b.item);
-};
-
 // Expand the size of the path by amount all around
 const expandBy = function (path, amount) {
     const center = path.position;
@@ -140,6 +136,5 @@ export {
     getRandomBoolean,
     scaleWithStrokes,
     snapDeltaToAngle,
-    sortItemsByZIndex,
-    sortHitResultsByZIndex
+    sortItemsByZIndex
 };

--- a/src/helper/math.js
+++ b/src/helper/math.js
@@ -44,10 +44,6 @@ const _getDepth = function (item) {
     return depth;
 };
 
-const sortHitResultsByZIndex = function (a, b) {
-    return sortItemsByZIndex(a.item, b.item);
-};
-
 const sortItemsByZIndex = function (a, b) {
     if (a === null || b === null) {
         return null;
@@ -84,6 +80,10 @@ const sortItemsByZIndex = function (a, b) {
 
     // No shared hierarchy
     return null;
+};
+
+const sortHitResultsByZIndex = function (a, b) {
+    return sortItemsByZIndex(a.item, b.item);
 };
 
 // Expand the size of the path by amount all around

--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -5,7 +5,7 @@ import keyMirror from 'keymirror';
 import Modes from '../../lib/modes';
 import {isBoundsItem} from '../item';
 import {hoverBounds, hoverItem} from '../guides';
-import {sortHitResultsByZIndex} from '../math';
+import {sortItemsByZIndex} from '../math';
 import {getSelectedLeafItems, getSelectedSegments} from '../selection';
 import MoveTool from './move-tool';
 import PointTool from './point-tool';
@@ -177,7 +177,7 @@ class ReshapeTool extends paper.Tool {
         // Get highest z-index result
         let hitResult;
         for (const result of hitResults) {
-            if (!hitResult || sortHitResultsByZIndex(hitResult, result) < 0) {
+            if (!hitResult || sortItemsByZIndex(hitResult.item, result.item) < 0) {
                 hitResult = result;
             }
         }

--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -76,6 +76,12 @@ class ReshapeTool extends paper.Tool {
 
         paper.settings.handleSize = 8;
     }
+    /**
+     * Returns the hit options for segments to use when conducting hit tests. Segments are only visible
+     * when the shape is selected. Segments take precedence, since they are always over curves and need
+     * to be grabbable. (Segments are the little curcles)
+     * @return {object} See paper.Item.hitTest for definition of options
+     */
     getSegmentHitOptions () {
         const hitOptions = {
             segments: true,
@@ -111,7 +117,8 @@ class ReshapeTool extends paper.Tool {
         return hitOptions;
     }
     /**
-     * Returns the hit options to use when conducting hit tests.
+     * Returns the hit options to use when conducting hit tests, not including handles, segments, or fills.
+     * Non-fills take precedence over fills.
      * @param {boolean} preselectedOnly True if we should only return results that are already
      *     selected.
      * @return {object} See paper.Item.hitTest for definition of options
@@ -133,6 +140,12 @@ class ReshapeTool extends paper.Tool {
         };
         return hitOptions;
     }
+    /**
+     * Returns the hit options for fills to use when conducting hit tests.
+     * @param {boolean} preselectedOnly True if we should only return results that are already
+     *     selected.
+     * @return {object} See paper.Item.hitTest for definition of options
+     */
     getFillHitOptions () {
         const hitOptions = {
             fill: true,
@@ -154,6 +167,11 @@ class ReshapeTool extends paper.Tool {
     setPrevHoveredItemId (prevHoveredItemId) {
         this.prevHoveredItemId = prevHoveredItemId;
     }
+    /**
+     * Given the point at which the mouse is, return the prioritized hit result, or null if nothing was hit.
+     * @param {paper.Point} point Point to hit test on canvas
+     * @return {?paper.HitResult} hitResult
+     */
     getHitResult (point) {
         // Prefer hits on segments to other types of hits, since segments always overlap curves.
         let hitResults =
@@ -239,8 +257,6 @@ class ReshapeTool extends paper.Tool {
             this.mode = ReshapeModes.FILL;
             this._modeMap[this.mode].onMouseDown(hitProperties);
         }
-
-        // @todo Trigger selection changed. Update styles based on selection.
     }
     handleMouseMove (event) {
         const hitResult = this.getHitResult(event.point);

--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -177,7 +177,7 @@ class ReshapeTool extends paper.Tool {
         // Get highest z-index result
         let hitResult;
         for (const result of hitResults) {
-            if (!hitResult || sortHitResultsByZIndex(hitResult, result) > 0) {
+            if (!hitResult || sortHitResultsByZIndex(hitResult, result) < 0) {
                 hitResult = result;
             }
         }
@@ -244,16 +244,17 @@ class ReshapeTool extends paper.Tool {
     }
     handleMouseMove (event) {
         const hitResult = this.getHitResult(event.point);
-        if (!hitResult) return;
-        const item = hitResult.item;
-
         let hoveredItem;
-        if (item.selected) {
-            hoveredItem = null;
-        } else if (isBoundsItem(item)) {
-            hoveredItem = hoverBounds(item);
-        } else {
-            hoveredItem = hoverItem(item);
+
+        if (hitResult) {
+            const item = hitResult.item;
+            if (item.selected) {
+                hoveredItem = null;
+            } else if (isBoundsItem(item)) {
+                hoveredItem = hoverBounds(item);
+            } else {
+                hoveredItem = hoverItem(item);
+            }
         }
 
         if ((!hoveredItem && this.prevHoveredItemId) || // There is no longer a hovered item

--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -246,10 +246,11 @@ class ReshapeTool extends paper.Tool {
         const hitResult = this.getHitResult(event.point);
         if (!hitResult) return;
         const item = hitResult.item;
-        if (item.selected) return;
 
         let hoveredItem;
-        if (isBoundsItem(item)) {
+        if (item.selected) {
+            hoveredItem = null;
+        } else if (isBoundsItem(item)) {
             hoveredItem = hoverBounds(item);
         } else {
             hoveredItem = hoverItem(item);

--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -79,7 +79,7 @@ class ReshapeTool extends paper.Tool {
     /**
      * Returns the hit options for segments to use when conducting hit tests. Segments are only visible
      * when the shape is selected. Segments take precedence, since they are always over curves and need
-     * to be grabbable. (Segments are the little curcles)
+     * to be grabbable. (Segments are the little circles)
      * @return {object} See paper.Item.hitTest for definition of options
      */
     getSelectedSegmentHitOptions () {
@@ -97,7 +97,7 @@ class ReshapeTool extends paper.Tool {
     /**
      * Returns the hit options for handles to use when conducting hit tests. Handles need to be done
      * separately because we want to ignore hidden handles, but we don't want hidden handles to negate
-     * legitimate hits on other things (like if the handle is over part of the fill)
+     * legitimate hits on other things (like if the handle is over part of the fill). (Handles are the diamonds)
      * @return {object} See paper.Item.hitTest for definition of options
      */
     getHandleHitOptions () {


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/150 (Can't select shape where invisible handles are)
Shapes should now be selectable where the invisible handles are.
Fixes https://github.com/LLK/scratch-paint/issues/520 (Hover outline doesn't necessarily match the next item you will select)
Mouse move now uses the same function as mouse down for hit detection, so these should match now
Fixes https://github.com/LLK/scratch-paint/issues/204 (Can't select front shape with the reshape tool if the back shape is selected)
Re-ordered the priority of hit detection so that you should be able to edit shapes that are fully in front of other shapes.

### Proposed Changes
1. Made mouse move and mouse down use the same hit algorithm in the reshape tool
2. Reordered priorities in the reshape tool so that handles that aren't visible don't interfere with hitting, and it's not impossible to edit shapes that are in front of other shapes

### Reason for Changes
Fix some frustrations with using reshape tool

### Testing
Test that hover selection (the thin blue line) is working as expected in select and reshape modes. Check that editing in reshape mode is working as expected.

https://llk.github.io/scratch-gui/handleBlock/