### PR TITLE
Make stroke width 0 when transparent

### DIFF
--- a/src/containers/stroke-color-indicator.jsx
+++ b/src/containers/stroke-color-indicator.jsx
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import bindAll from 'lodash.bindall';
 import {changeStrokeColor} from '../reducers/stroke-color';
+import {changeStrokeWidth} from '../reducers/stroke-width';
 import {openStrokeColor, closeStrokeColor} from '../reducers/modals';
 import Modes from '../lib/modes';
 import Formats from '../lib/format';
 import {isBitmap} from '../lib/format';
 
 import StrokeColorIndicatorComponent from '../components/stroke-color-indicator.jsx';
-import {applyStrokeColorToSelection} from '../helper/style-path';
+import {applyStrokeColorToSelection, applyStrokeWidthToSelection} from '../helper/style-path';
 
 class StrokeColorIndicator extends React.Component {
     constructor (props) {
@@ -31,10 +32,17 @@ class StrokeColorIndicator extends React.Component {
         }
     }
     handleChangeStrokeColor (newColor) {
+        if (this.props.strokeColor === null && newColor !== null) {
+            this._hasChanged = applyStrokeWidthToSelection(1, this.props.textEditTarget) || this._hasChanged;
+            this.props.onChangeStrokeWidth(1);
+        } else if (this.props.strokeColor !== null && newColor === null) {
+            this._hasChanged = applyStrokeWidthToSelection(0, this.props.textEditTarget) || this._hasChanged;
+            this.props.onChangeStrokeWidth(0);
+        }
         // Apply color and update redux, but do not update svg until picker closes.
-        const isDifferent =
-            applyStrokeColorToSelection(newColor, isBitmap(this.props.format), this.props.textEditTarget);
-        this._hasChanged = this._hasChanged || isDifferent;
+        this._hasChanged =
+            applyStrokeColorToSelection(newColor, isBitmap(this.props.format), this.props.textEditTarget) ||
+            this._hasChanged;
         this.props.onChangeStrokeColor(newColor);
     }
     handleCloseStrokeColor () {
@@ -68,6 +76,9 @@ const mapDispatchToProps = dispatch => ({
     onChangeStrokeColor: strokeColor => {
         dispatch(changeStrokeColor(strokeColor));
     },
+    onChangeStrokeWidth: strokeWidth => {
+        dispatch(changeStrokeWidth(strokeWidth));
+    },
     onOpenStrokeColor: () => {
         dispatch(openStrokeColor());
     },
@@ -77,10 +88,10 @@ const mapDispatchToProps = dispatch => ({
 });
 
 StrokeColorIndicator.propTypes = {
-    disabled: PropTypes.bool.isRequired,
     format: PropTypes.oneOf(Object.keys(Formats)),
     isEyeDropping: PropTypes.bool.isRequired,
     onChangeStrokeColor: PropTypes.func.isRequired,
+    onChangeStrokeWidth: PropTypes.func.isRequired,
     onCloseStrokeColor: PropTypes.func.isRequired,
     onUpdateImage: PropTypes.func.isRequired,
     strokeColor: PropTypes.string,

--- a/src/containers/stroke-width-indicator.jsx
+++ b/src/containers/stroke-width-indicator.jsx
@@ -2,10 +2,12 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 import bindAll from 'lodash.bindall';
+import parseColor from 'parse-color';
 import {changeStrokeColor} from '../reducers/stroke-color';
 import {changeStrokeWidth} from '../reducers/stroke-width';
 import StrokeWidthIndicatorComponent from '../components/stroke-width-indicator.jsx';
-import {applyStrokeColorToSelection, applyStrokeWidthToSelection} from '../helper/style-path';
+import {getSelectedLeafItems} from '../helper/selection';
+import {applyStrokeColorToSelection, applyStrokeWidthToSelection, getColorsFromSelection, MIXED} from '../helper/style-path';
 import Modes from '../lib/modes';
 import Formats from '../lib/format';
 import {isBitmap} from '../lib/format';
@@ -18,17 +20,18 @@ class StrokeWidthIndicator extends React.Component {
         ]);
     }
     handleChangeStrokeWidth (newWidth) {
-        let changed = false;
+        let changed = applyStrokeWidthToSelection(newWidth, this.props.textEditTarget);
         if (this.props.strokeWidth === 0 && newWidth > 0) {
-            changed = applyStrokeColorToSelection('#000', isBitmap(this.props.format), this.props.textEditTarget) ||
-                changed;
-            this.props.onChangeStrokeColor('#000');
-        } else if (this.props.strokeWidth > 0 && newWidth === 0) {
-            changed = applyStrokeColorToSelection(null, isBitmap(this.props.format), this.props.textEditTarget) ||
-                changed;
-            this.props.onChangeStrokeColor(null);
+            let currentColor = getColorsFromSelection(getSelectedLeafItems(), isBitmap(this.props.format)).strokeColor;
+            if (currentColor === null) {
+                changed = applyStrokeColorToSelection('#000', isBitmap(this.props.format), this.props.textEditTarget) ||
+                    changed;
+                currentColor = '#000';
+            } else if (currentColor !== MIXED) {
+                currentColor = parseColor(currentColor).hex;
+            }
+            this.props.onChangeStrokeColor(currentColor);
         }
-        changed = applyStrokeWidthToSelection(newWidth, this.props.textEditTarget) || changed;
         this.props.onChangeStrokeWidth(newWidth);
         if (changed) this.props.onUpdateImage();
     }

--- a/src/containers/stroke-width-indicator.jsx
+++ b/src/containers/stroke-width-indicator.jsx
@@ -7,7 +7,8 @@ import {changeStrokeColor} from '../reducers/stroke-color';
 import {changeStrokeWidth} from '../reducers/stroke-width';
 import StrokeWidthIndicatorComponent from '../components/stroke-width-indicator.jsx';
 import {getSelectedLeafItems} from '../helper/selection';
-import {applyStrokeColorToSelection, applyStrokeWidthToSelection, getColorsFromSelection, MIXED} from '../helper/style-path';
+import {applyStrokeColorToSelection, applyStrokeWidthToSelection, getColorsFromSelection, MIXED}
+    from '../helper/style-path';
 import Modes from '../lib/modes';
 import Formats from '../lib/format';
 import {isBitmap} from '../lib/format';
@@ -21,7 +22,7 @@ class StrokeWidthIndicator extends React.Component {
     }
     handleChangeStrokeWidth (newWidth) {
         let changed = applyStrokeWidthToSelection(newWidth, this.props.textEditTarget);
-        if (this.props.strokeWidth === 0 && newWidth > 0) {
+        if ((!this.props.strokeWidth || this.props.strokeWidth === 0) && newWidth > 0) {
             let currentColor = getColorsFromSelection(getSelectedLeafItems(), isBitmap(this.props.format)).strokeColor;
             if (currentColor === null) {
                 changed = applyStrokeColorToSelection('#000', isBitmap(this.props.format), this.props.textEditTarget) ||

--- a/src/containers/stroke-width-indicator.jsx
+++ b/src/containers/stroke-width-indicator.jsx
@@ -2,10 +2,13 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 import bindAll from 'lodash.bindall';
+import {changeStrokeColor} from '../reducers/stroke-color';
 import {changeStrokeWidth} from '../reducers/stroke-width';
 import StrokeWidthIndicatorComponent from '../components/stroke-width-indicator.jsx';
-import {applyStrokeWidthToSelection} from '../helper/style-path';
+import {applyStrokeColorToSelection, applyStrokeWidthToSelection} from '../helper/style-path';
 import Modes from '../lib/modes';
+import Formats from '../lib/format';
+import {isBitmap} from '../lib/format';
 
 class StrokeWidthIndicator extends React.Component {
     constructor (props) {
@@ -15,10 +18,19 @@ class StrokeWidthIndicator extends React.Component {
         ]);
     }
     handleChangeStrokeWidth (newWidth) {
-        if (applyStrokeWidthToSelection(newWidth, this.props.textEditTarget)) {
-            this.props.onUpdateImage();
+        let changed = false;
+        if (this.props.strokeWidth === 0 && newWidth > 0) {
+            changed = applyStrokeColorToSelection('#000', isBitmap(this.props.format), this.props.textEditTarget) ||
+                changed;
+            this.props.onChangeStrokeColor('#000');
+        } else if (this.props.strokeWidth > 0 && newWidth === 0) {
+            changed = applyStrokeColorToSelection(null, isBitmap(this.props.format), this.props.textEditTarget) ||
+                changed;
+            this.props.onChangeStrokeColor(null);
         }
+        changed = applyStrokeWidthToSelection(newWidth, this.props.textEditTarget) || changed;
         this.props.onChangeStrokeWidth(newWidth);
+        if (changed) this.props.onUpdateImage();
     }
     render () {
         return (
@@ -35,10 +47,14 @@ const mapStateToProps = state => ({
     disabled: state.scratchPaint.mode === Modes.BRUSH ||
         state.scratchPaint.mode === Modes.TEXT ||
         state.scratchPaint.mode === Modes.FILL,
+    format: state.scratchPaint.format,
     strokeWidth: state.scratchPaint.color.strokeWidth,
     textEditTarget: state.scratchPaint.textEditTarget
 });
 const mapDispatchToProps = dispatch => ({
+    onChangeStrokeColor: strokeColor => {
+        dispatch(changeStrokeColor(strokeColor));
+    },
     onChangeStrokeWidth: strokeWidth => {
         dispatch(changeStrokeWidth(strokeWidth));
     }
@@ -46,6 +62,8 @@ const mapDispatchToProps = dispatch => ({
 
 StrokeWidthIndicator.propTypes = {
     disabled: PropTypes.bool.isRequired,
+    format: PropTypes.oneOf(Object.keys(Formats)),
+    onChangeStrokeColor: PropTypes.func.isRequired,
     onChangeStrokeWidth: PropTypes.func.isRequired,
     onUpdateImage: PropTypes.func.isRequired,
     strokeWidth: PropTypes.number,

--- a/src/helper/style-path.js
+++ b/src/helper/style-path.js
@@ -443,7 +443,7 @@ const getColorsFromSelection = function (selectedItems, bitmapMode) {
         }
     }
     // Convert selection gradient type from horizontal to vertical if first item is exactly vertical
-    if (selectionGradientType !== GradientTypes.SOLID) {
+    if (selectedItems && selectedItems.length && selectionGradientType !== GradientTypes.SOLID) {
         let firstItem = selectedItems[0];
         if (firstItem.parent instanceof paper.CompoundPath) firstItem = firstItem.parent;
         const direction = firstItem.fillColor.destination.subtract(firstItem.fillColor.origin);

--- a/src/helper/style-path.js
+++ b/src/helper/style-path.js
@@ -111,7 +111,7 @@ const applyFillColorToSelection = function (colorString, colorIndex, isSolidGrad
         }
 
         // In bitmap mode, fill color applies to the stroke if there is a stroke
-        if (bitmapMode && item.strokeColor !== null && item.strokeWidth !== 0) {
+        if (bitmapMode && item.strokeColor !== null && item.strokeWidth) {
             if (!_colorMatch(item.strokeColor, colorString)) {
                 changed = true;
                 item.strokeColor = colorString;
@@ -403,7 +403,7 @@ const getColorsFromSelection = function (selectedItems, bitmapMode) {
                 } else if (item.strokeColor.type === 'gradient') {
                     itemStrokeColorString = MIXED;
                 } else {
-                    itemStrokeColorString = item.strokeColor.alpha === 0 || item.strokeWidth === 0 ?
+                    itemStrokeColorString = item.strokeColor.alpha === 0 || !item.strokeWidth ?
                         null :
                         item.strokeColor.toCSS();
                 }

--- a/src/helper/style-path.js
+++ b/src/helper/style-path.js
@@ -434,7 +434,6 @@ const getColorsFromSelection = function (selectedItems, bitmapMode) {
                 selectionFillColor2String = MIXED;
             }
             if (itemStrokeColorString !== selectionStrokeColorString) {
-                debugger;
                 selectionStrokeColorString = MIXED;
             }
             const itemStrokeWidth = itemStrokeColorString ? item.strokeWidth : 0;

--- a/src/helper/style-path.js
+++ b/src/helper/style-path.js
@@ -1,6 +1,6 @@
 import paper from '@scratch/paper';
 import {getSelectedLeafItems} from './selection';
-import {isPGTextItem, isPointTextItem} from './item';
+import {isPointTextItem} from './item';
 import {isGroup} from './group';
 import {getItems} from './selection';
 import GradientTypes from '../lib/gradient-types';
@@ -306,32 +306,7 @@ const applyStrokeColorToSelection = function (colorString, bitmapMode, textEditT
         if (item.parent instanceof paper.CompoundPath) {
             item = item.parent;
         }
-        if (isPGTextItem(item)) {
-            if (item.children) {
-                for (const child of item.children) {
-                    if (child.children) {
-                        for (const path of child.children) {
-                            if (!path.data.isPGGlyphRect) {
-                                if (!_colorMatch(path.strokeColor, colorString)) {
-                                    changed = true;
-                                    path.strokeColor = colorString;
-                                }
-                            }
-                        }
-                    } else if (!child.data.isPGGlyphRect) {
-                        if (child.strokeColor !== colorString) {
-                            changed = true;
-                            child.strokeColor = colorString;
-                        }
-                    }
-                }
-            } else if (!item.data.isPGGlyphRect) {
-                if (!_colorMatch(item.strokeColor, colorString)) {
-                    changed = true;
-                    item.strokeColor = colorString;
-                }
-            }
-        } else if (!_colorMatch(item.strokeColor, colorString)) {
+        if (!_colorMatch(item.strokeColor, colorString)) {
             changed = true;
             item.strokeColor = colorString;
         }
@@ -428,10 +403,12 @@ const getColorsFromSelection = function (selectedItems, bitmapMode) {
                 } else if (item.strokeColor.type === 'gradient') {
                     itemStrokeColorString = MIXED;
                 } else {
-                    itemStrokeColorString = item.strokeColor.alpha === 0 ?
+                    itemStrokeColorString = item.strokeColor.alpha === 0 || item.strokeWidth === 0 ?
                         null :
                         item.strokeColor.toCSS();
                 }
+            } else {
+                itemStrokeColorString = null;
             }
             // check every style against the first of the items
             if (firstChild) {
@@ -440,7 +417,7 @@ const getColorsFromSelection = function (selectedItems, bitmapMode) {
                 selectionFillColor2String = itemFillColor2String;
                 selectionStrokeColorString = itemStrokeColorString;
                 selectionGradientType = itemGradientType;
-                selectionStrokeWidth = item.strokeWidth;
+                selectionStrokeWidth = itemStrokeColorString ? item.strokeWidth : 0;
                 if (item.strokeWidth && item.data && item.data.zoomLevel) {
                     selectionThickness = item.strokeWidth / item.data.zoomLevel;
                 }
@@ -457,9 +434,11 @@ const getColorsFromSelection = function (selectedItems, bitmapMode) {
                 selectionFillColor2String = MIXED;
             }
             if (itemStrokeColorString !== selectionStrokeColorString) {
+                debugger;
                 selectionStrokeColorString = MIXED;
             }
-            if (selectionStrokeWidth !== item.strokeWidth) {
+            const itemStrokeWidth = itemStrokeColorString ? item.strokeWidth : 0;
+            if (selectionStrokeWidth !== itemStrokeWidth) {
                 selectionStrokeWidth = null;
             }
         }

--- a/src/reducers/stroke-color.js
+++ b/src/reducers/stroke-color.js
@@ -1,5 +1,6 @@
 import log from '../log/log';
 import {CHANGE_SELECTED_ITEMS} from './selected-items';
+import {CHANGE_STROKE_WIDTH} from './stroke-width';
 import {getColorsFromSelection} from '../helper/style-path';
 
 const CHANGE_STROKE_COLOR = 'scratch-paint/stroke-color/CHANGE_STROKE_COLOR';
@@ -10,6 +11,11 @@ const regExp = /^#([0-9a-f]{3}){1,2}$/i;
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
     switch (action.type) {
+    case CHANGE_STROKE_WIDTH:
+        if (!isNaN(action.strokeWidth) && Math.max(0, action.strokeWidth) === 0) {
+            return null; // Change color to transparent if stroke width is set to 0
+        }
+        return state;
     case CHANGE_STROKE_COLOR:
         if (!regExp.test(action.strokeColor) && action.strokeColor !== null) {
             log.warn(`Invalid hex color code: ${action.fillColor}`);
@@ -41,5 +47,6 @@ const changeStrokeColor = function (strokeColor) {
 
 export {
     reducer as default,
-    changeStrokeColor
+    changeStrokeColor,
+    CHANGE_STROKE_COLOR
 };

--- a/src/reducers/stroke-color.js
+++ b/src/reducers/stroke-color.js
@@ -1,6 +1,7 @@
 import log from '../log/log';
 import {CHANGE_SELECTED_ITEMS} from './selected-items';
-import {getColorsFromSelection} from '../helper/style-path';
+import {CHANGE_STROKE_WIDTH} from './stroke-width';
+import {getColorsFromSelection, MIXED} from '../helper/style-path';
 
 const CHANGE_STROKE_COLOR = 'scratch-paint/stroke-color/CHANGE_STROKE_COLOR';
 const initialState = '#000';
@@ -10,8 +11,13 @@ const regExp = /^#([0-9a-f]{3}){1,2}$/i;
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
     switch (action.type) {
+    case CHANGE_STROKE_WIDTH:
+        if (Math.max(0, action.strokeWidth) === 0) {
+            return null;
+        }
+        return state;
     case CHANGE_STROKE_COLOR:
-        if (!regExp.test(action.strokeColor) && action.strokeColor !== null) {
+        if (!regExp.test(action.strokeColor) && action.strokeColor !== null && action.strokeColor !== MIXED) {
             log.warn(`Invalid hex color code: ${action.fillColor}`);
             return state;
         }

--- a/src/reducers/stroke-color.js
+++ b/src/reducers/stroke-color.js
@@ -1,6 +1,5 @@
 import log from '../log/log';
 import {CHANGE_SELECTED_ITEMS} from './selected-items';
-import {CHANGE_STROKE_WIDTH} from './stroke-width';
 import {getColorsFromSelection} from '../helper/style-path';
 
 const CHANGE_STROKE_COLOR = 'scratch-paint/stroke-color/CHANGE_STROKE_COLOR';
@@ -11,13 +10,6 @@ const regExp = /^#([0-9a-f]{3}){1,2}$/i;
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
     switch (action.type) {
-    case CHANGE_STROKE_WIDTH:
-        if (!isNaN(action.strokeWidth) && Math.max(0, action.strokeWidth) === 0) {
-            return null; // Change color to transparent if stroke width is set to 0
-        } else if (state === null && action.strokeWidth > 0) {
-            return '#000';
-        }
-        return state;
     case CHANGE_STROKE_COLOR:
         if (!regExp.test(action.strokeColor) && action.strokeColor !== null) {
             log.warn(`Invalid hex color code: ${action.fillColor}`);
@@ -49,6 +41,5 @@ const changeStrokeColor = function (strokeColor) {
 
 export {
     reducer as default,
-    changeStrokeColor,
-    CHANGE_STROKE_COLOR
+    changeStrokeColor
 };

--- a/src/reducers/stroke-color.js
+++ b/src/reducers/stroke-color.js
@@ -14,6 +14,8 @@ const reducer = function (state, action) {
     case CHANGE_STROKE_WIDTH:
         if (!isNaN(action.strokeWidth) && Math.max(0, action.strokeWidth) === 0) {
             return null; // Change color to transparent if stroke width is set to 0
+        } else if (state === null && action.strokeWidth > 0) {
+            return '#000';
         }
         return state;
     case CHANGE_STROKE_COLOR:

--- a/src/reducers/stroke-width.js
+++ b/src/reducers/stroke-width.js
@@ -1,6 +1,5 @@
 import log from '../log/log';
 import {CHANGE_SELECTED_ITEMS} from './selected-items';
-import {CHANGE_STROKE_COLOR} from './stroke-color';
 import {getColorsFromSelection} from '../helper/style-path';
 
 const CHANGE_STROKE_WIDTH = 'scratch-paint/stroke-width/CHANGE_STROKE_WIDTH';
@@ -10,13 +9,6 @@ const initialState = 4;
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
     switch (action.type) {
-    case CHANGE_STROKE_COLOR:
-        if (action.strokeColor === null) {
-            return 0; // If stroke color is set to transparent, set stroke width to 0
-        } else if (state === 0 && action.strokeColor !== null) {
-            return 1; // If stroke color is changed from transparent, set a stroke width
-        }
-        return state;
     case CHANGE_STROKE_WIDTH:
         if (isNaN(action.strokeWidth)) {
             log.warn(`Invalid brush size: ${action.strokeWidth}`);
@@ -49,6 +41,5 @@ const changeStrokeWidth = function (strokeWidth) {
 export {
     reducer as default,
     changeStrokeWidth,
-    CHANGE_STROKE_WIDTH,
     MAX_STROKE_WIDTH
 };

--- a/src/reducers/stroke-width.js
+++ b/src/reducers/stroke-width.js
@@ -1,5 +1,6 @@
 import log from '../log/log';
 import {CHANGE_SELECTED_ITEMS} from './selected-items';
+import {CHANGE_STROKE_COLOR} from './stroke-color';
 import {getColorsFromSelection} from '../helper/style-path';
 
 const CHANGE_STROKE_WIDTH = 'scratch-paint/stroke-width/CHANGE_STROKE_WIDTH';
@@ -9,6 +10,11 @@ const initialState = 4;
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
     switch (action.type) {
+    case CHANGE_STROKE_COLOR:
+        if (action.strokeColor === null) {
+            return 0; // If stroke color is set to transparent, set stroke width to 0
+        }
+        return state;
     case CHANGE_STROKE_WIDTH:
         if (isNaN(action.strokeWidth)) {
             log.warn(`Invalid brush size: ${action.strokeWidth}`);
@@ -41,5 +47,6 @@ const changeStrokeWidth = function (strokeWidth) {
 export {
     reducer as default,
     changeStrokeWidth,
+    CHANGE_STROKE_WIDTH,
     MAX_STROKE_WIDTH
 };

--- a/src/reducers/stroke-width.js
+++ b/src/reducers/stroke-width.js
@@ -41,5 +41,6 @@ const changeStrokeWidth = function (strokeWidth) {
 export {
     reducer as default,
     changeStrokeWidth,
+    CHANGE_STROKE_WIDTH,
     MAX_STROKE_WIDTH
 };

--- a/src/reducers/stroke-width.js
+++ b/src/reducers/stroke-width.js
@@ -13,6 +13,8 @@ const reducer = function (state, action) {
     case CHANGE_STROKE_COLOR:
         if (action.strokeColor === null) {
             return 0; // If stroke color is set to transparent, set stroke width to 0
+        } else if (state === 0 && action.strokeColor !== null) {
+            return 1; // If stroke color is changed from transparent, set a stroke width
         }
         return state;
     case CHANGE_STROKE_WIDTH:

--- a/test/unit/stroke-color-reducer.test.js
+++ b/test/unit/stroke-color-reducer.test.js
@@ -34,15 +34,27 @@ test('changeStrokeColorViaSelectedItems', () => {
 
     const strokeColor1 = 6;
     const strokeColor2 = null; // transparent
-    let selectedItems = [mockPaperRootItem({strokeColor: strokeColor1})];
+    let selectedItems = [mockPaperRootItem({strokeColor: strokeColor1, strokeWidth: 1})];
     expect(strokeColorReducer(defaultState /* state */, setSelectedItems(selectedItems) /* action */))
         .toEqual(strokeColor1);
-    selectedItems = [mockPaperRootItem({strokeColor: strokeColor2})];
+    selectedItems = [mockPaperRootItem({strokeColor: strokeColor2, strokeWidth: 1})];
     expect(strokeColorReducer(defaultState /* state */, setSelectedItems(selectedItems) /* action */))
         .toEqual(strokeColor2);
-    selectedItems = [mockPaperRootItem({strokeColor: strokeColor1}), mockPaperRootItem({strokeColor: strokeColor2})];
+    selectedItems = [mockPaperRootItem({strokeColor: strokeColor1, strokeWidth: 1}),
+        mockPaperRootItem({strokeColor: strokeColor2, strokeWidth: 1})];
     expect(strokeColorReducer(defaultState /* state */, setSelectedItems(selectedItems) /* action */))
         .toEqual(MIXED);
+});
+
+test('showNoStrokeColorIfNoStrokeWidth', () => {
+    let defaultState;
+
+    let selectedItems = [mockPaperRootItem({strokeColor: '#fff', strokeWidth: null})];
+    expect(strokeColorReducer(defaultState /* state */, setSelectedItems(selectedItems) /* action */))
+        .toEqual(null);
+    selectedItems = [mockPaperRootItem({strokeColor: '#fff', strokeWidth: 0})];
+    expect(strokeColorReducer(defaultState /* state */, setSelectedItems(selectedItems) /* action */))
+        .toEqual(null);
 });
 
 test('invalidChangeStrokeColor', () => {

--- a/test/unit/stroke-width-reducer.test.js
+++ b/test/unit/stroke-width-reducer.test.js
@@ -30,15 +30,24 @@ test('changeStrokeWidthViaSelectedItems', () => {
 
     const strokeWidth1 = 6;
     let strokeWidth2; // no outline
-    let selectedItems = [mockPaperRootItem({strokeWidth: strokeWidth1})];
+    let selectedItems = [mockPaperRootItem({strokeColor: '#000', strokeWidth: strokeWidth1})];
     expect(strokeWidthReducer(defaultState /* state */, setSelectedItems(selectedItems) /* action */))
         .toEqual(strokeWidth1);
-    selectedItems = [mockPaperRootItem({strokeWidth: strokeWidth2})];
+    selectedItems = [mockPaperRootItem({strokeColor: '#000', strokeWidth: strokeWidth2})];
     expect(strokeWidthReducer(defaultState /* state */, setSelectedItems(selectedItems) /* action */))
         .toEqual(0); // Convert no outline to stroke width 0
-    selectedItems = [mockPaperRootItem({strokeWidth: strokeWidth1}), mockPaperRootItem({strokeWidth: strokeWidth2})];
+    selectedItems = [mockPaperRootItem({strokeColor: '#000', strokeWidth: strokeWidth1}),
+        mockPaperRootItem({strokeColor: '#000', strokeWidth: strokeWidth2})];
     expect(strokeWidthReducer(defaultState /* state */, setSelectedItems(selectedItems) /* action */))
         .toEqual(null); // null indicates mixed for stroke width
+});
+
+test('showNoStrokeWidthIfNoStrokeColor', () => {
+    let defaultState;
+
+    const selectedItems = [mockPaperRootItem({strokeColor: null, strokeWidth: 10})];
+    expect(strokeWidthReducer(defaultState /* state */, setSelectedItems(selectedItems) /* action */))
+        .toEqual(0);
 });
 
 test('invalidChangestrokeWidth', () => {


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/279

### Proposed Changes
When stroke color is transparent, make the width report 0
When stroke width is 0, make the color report transparent

When the stroke color is changed from transparent, make the width 1
When stroke width is changed from 0, make the color black

### Reason for Changes
Don't have hidden properties.
When you make changes, they are visible.