### PR TITLE
Add Gaidhlig (gd) to the ‘hide-label’ locales

### DIFF
--- a/src/lib/hide-label.js
+++ b/src/lib/hide-label.js
@@ -6,6 +6,7 @@ const localeTooBig = [
     'et',
     'el',
     'ga',
+    'gd',
     'gl',
     'mi',
     'nl',


### PR DESCRIPTION
### Resolves

Fixes #620 

### Proposed Changes

Adds `gd` to the list of languages that should have the paint-editor labels hidden.

### Reason for Changes

Gaidhlig strings are too long for the paint-editor buttons. 

### Test Coverage
Manual resting:
* switch language to Gaidhlig in the Scratch editor
* open the costume editor, the buttons should not have labels, there should be translated tooltips on hover
* switch to bitmap, the buttons should not have labels, but translated tooltips are there 
