### PR TITLE
Cut off text2

### DIFF
--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -369,7 +369,7 @@ const convertToBitmap = function (clearSelectedItems, onUpdateImage) {
 
     // Export svg
     const guideLayers = hideGuideLayers(true /* includeRaster */);
-    const bounds = paper.project.activeLayer.visibleBounds;
+    const bounds = paper.project.activeLayer.drawnBounds;
     const svg = paper.project.exportSVG({
         bounds: 'content',
         matrix: new paper.Matrix().translate(-bounds.x, -bounds.y)

--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -369,7 +369,7 @@ const convertToBitmap = function (clearSelectedItems, onUpdateImage) {
 
     // Export svg
     const guideLayers = hideGuideLayers(true /* includeRaster */);
-    const bounds = paper.project.activeLayer.bounds;
+    const bounds = paper.project.activeLayer.visibleBounds;
     const svg = paper.project.exportSVG({
         bounds: 'content',
         matrix: new paper.Matrix().translate(-bounds.x, -bounds.y)

--- a/src/helper/tools/text-tool.js
+++ b/src/helper/tools/text-tool.js
@@ -387,7 +387,7 @@ class TextTool extends paper.Tool {
         if (!this.textBox || !this.textBox.parent) return;
 
         // @todo get crisp text https://github.com/LLK/scratch-paint/issues/508
-        const textRaster = this.textBox.rasterize(72, false /* insert */, this._getTextSize(this.textBox));
+        const textRaster = this.textBox.rasterize(72, false /* insert */, this.textBox.drawnBounds);
         this.textBox.remove();
         this.textBox = null;
         getRaster().drawImage(
@@ -395,61 +395,6 @@ class TextTool extends paper.Tool {
             new paper.Point(Math.floor(textRaster.bounds.x), Math.floor(textRaster.bounds.y))
         );
         this.onUpdateImage();
-    }
-    _getTextSize (textBox) {
-        const numLines = textBox._lines.length;
-        const leading = textBox._style.getLeading();
-
-        // Create SVG dom element from text
-        const svg = SvgElement.create('svg', {
-            version: '1.1',
-            xmlns: SvgElement.svg
-        });
-        const node = SvgElement.create('text');
-        node.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
-        svg.appendChild(node);
-        for (let i = 0; i < numLines; i++) {
-            const tspanNode = SvgElement.create('tspan', {
-                x: '0',
-                dy: i === 0 ? '0' : `${leading}px`
-            });
-            tspanNode.textContent = textBox._lines[i];
-            node.appendChild(tspanNode);
-        }
-
-        // Append to dom
-        const element = document.createElement('span');
-        element.style.visibility = ('hidden');
-        element.style.whiteSpace = 'pre';
-        element.style.fontSize = `${textBox.fontSize}px`;
-        element.style.fontFamily = textBox.font;
-        element.style.lineHeight = textBox.leading / textBox.fontSize;
-
-        // Measure bbox
-        let bbox;
-        try {
-            element.appendChild(svg);
-            // Is element width available before appending?
-            document.body.appendChild(element);
-            // Take the bounding box.
-            bbox = svg.getBBox();
-        } finally {
-            // Always destroy the element, even if, for example, getBBox throws.
-            document.body.removeChild(element);
-        }
-
-        // Enlarge the bbox from the largest found stroke width
-        // This may have false-positives, but at least the bbox will always
-        // contain the full graphic including strokes.
-        const halfStrokeWidth = textBox.strokeWidth / 2;
-        const width = bbox.width + (halfStrokeWidth * 2);
-        const height = bbox.height + (halfStrokeWidth * 2);
-        const x = bbox.x - halfStrokeWidth;
-        const y = bbox.y - halfStrokeWidth;
-
-        // Add 1 to give space for text cursor
-        const rect = new paper.Rectangle(x, y, width + 1, Math.max(height, numLines * leading));
-        return textBox.matrix ? textBox.matrix._transformBounds(rect, rect) : rect;
     }
     deactivateTool () {
         if (this.textBox && this.textBox.content.trim() === '') {

--- a/src/helper/tools/text-tool.js
+++ b/src/helper/tools/text-tool.js
@@ -5,7 +5,6 @@ import BoundingBoxTool from '../selection-tools/bounding-box-tool';
 import NudgeTool from '../selection-tools/nudge-tool';
 import {hoverBounds} from '../guides';
 import {getRaster} from '../layer';
-import {SvgElement} from 'scratch-svg-renderer';
 
 /**
  * Tool for adding text. Text elements have limited editability; they can't be reshaped,

--- a/src/hocs/update-image-hoc.jsx
+++ b/src/hocs/update-image-hoc.jsx
@@ -103,7 +103,7 @@ const UpdateImageHOC = function (WrappedComponent) {
 
             // Export at 0.5x
             scaleWithStrokes(paper.project.activeLayer, .5, new paper.Point());
-            const bounds = paper.project.activeLayer.bounds;
+            const bounds = paper.project.activeLayer.visibleBounds;
             // @todo (https://github.com/LLK/scratch-paint/issues/445) generate view box
             this.props.onUpdateImage(
                 true /* isVector */,

--- a/src/hocs/update-image-hoc.jsx
+++ b/src/hocs/update-image-hoc.jsx
@@ -59,7 +59,7 @@ const UpdateImageHOC = function (WrappedComponent) {
             }
             // Anything that is selected is on the vector layer waiting to be committed to the bitmap layer.
             // Plaster the selection onto the raster layer before exporting, if there is a selection.
-            const plasteredRaster = getRaster().getSubRaster(getRaster().bounds);
+            const plasteredRaster = getRaster().getSubRaster(getRaster().bounds); // Clone the raster layer
             plasteredRaster.remove(); // Don't insert
             const selectedItems = getSelectedLeafItems();
             if (selectedItems.length === 1) {
@@ -80,10 +80,11 @@ const UpdateImageHOC = function (WrappedComponent) {
                 } else if (item instanceof paper.Shape && item.type === 'ellipse') {
                     commitOvalToBitmap(item, plasteredRaster);
                 } else if (item instanceof paper.PointText) {
-                    const textRaster = item.rasterize(72, false /* insert */);
+                    const bounds = item.drawnBounds;
+                    const textRaster = item.rasterize(72, false /* insert */, bounds);
                     plasteredRaster.drawImage(
                         textRaster.canvas,
-                        new paper.Point(Math.floor(textRaster.bounds.x), Math.floor(textRaster.bounds.y))
+                        new paper.Point(Math.floor(bounds.x), Math.floor(bounds.y))
                     );
                 }
             }
@@ -103,7 +104,7 @@ const UpdateImageHOC = function (WrappedComponent) {
 
             // Export at 0.5x
             scaleWithStrokes(paper.project.activeLayer, .5, new paper.Point());
-            const bounds = paper.project.activeLayer.visibleBounds;
+            const bounds = paper.project.activeLayer.drawnBounds;
             // @todo (https://github.com/LLK/scratch-paint/issues/445) generate view box
             this.props.onUpdateImage(
                 true /* isVector */,


### PR DESCRIPTION
### Resolves
Fixes LLK/scratch-paint#434
Fixes https://github.com/LLK/scratch-paint/issues/647

### Proposed Changes
Use drawnBounds (added in https://github.com/LLK/paper.js/pull/22) when converting text to bitmap or exporting SVGs to the renderer

### Reason for Changes
In these 2 cases, we need to include the bounds of everywhere text draws in order to not cut it off

### Test Coverage
Tested manually, mostly with the capital H in Marker and Curly, and zalgo.