### PR TITLE
Fix issues handling rasters in reshape

### DIFF
--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -87,6 +87,7 @@ class ReshapeTool extends paper.Tool {
             segments: true,
             tolerance: ReshapeTool.TOLERANCE / paper.view.zoom,
             match: hitResult => {
+                if (hitResult.type !== 'segment') return false;
                 if (hitResult.item.data && hitResult.item.data.noHover) return false;
                 if (!hitResult.item.selected) return false;
                 return true;
@@ -108,7 +109,7 @@ class ReshapeTool extends paper.Tool {
                 if (hitResult.item.data && hitResult.item.data.noHover) return false;
                 // Only hit test against handles that are visible, that is,
                 // their segment is selected
-                if (!hitResult.segment.selected) return false;
+                if (!hitResult.segment || !hitResult.segment.selected) return false;
                 // If the entire shape is selected, handles are hidden
                 if (hitResult.item.fullySelected) return false;
                 return true;
@@ -131,6 +132,7 @@ class ReshapeTool extends paper.Tool {
             guide: false,
             tolerance: ReshapeTool.TOLERANCE / paper.view.zoom,
             match: hitResult => {
+                if (hitResult.type !== 'stroke' || hitResult.type !== 'curve') return false;
                 if (!hitResult.item.selected) return false;
                 if (hitResult.item.data && hitResult.item.data.noHover) return false;
                 return true;


### PR DESCRIPTION
### Resolves
https://github.com/LLK/scratch-paint/issues/742

### Proposed Changes
Filter out rasters from several of the hit tests

### Reason for Changes
Rasters are capturing hits they shouldn't be capturing, causing reshape to fail when there is a raster in the background.

### Test Coverage
Tested using the reshape tool on a path in front of a raster. (To create a raster, e.g. upload a bitmap image, then convert to vector)