### PR TITLE
Revert "Wait for other callbacks before load SVG code"

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -27,7 +27,6 @@ class PaperCanvas extends React.Component {
         bindAll(this, [
             'setCanvas',
             'importSvg',
-            'initializeSvg',
             'maybeZoomToFit',
             'switchCostume'
         ]);
@@ -172,64 +171,58 @@ class PaperCanvas extends React.Component {
                     performSnapshot(paperCanvas.props.undoSnapshot, Formats.VECTOR_SKIP_CONVERT);
                     return;
                 }
-                item.remove();
+                const itemWidth = item.bounds.width;
+                const itemHeight = item.bounds.height;
 
-                // Without the callback, rasters' load function has not been called yet, and they are
-                // positioned incorrectly
-                window.setTimeout(() => {
-                    paperCanvas.initializeSvg(item, rotationCenterX, rotationCenterY, viewBox);
-                }, 0);
+                // Remove viewbox
+                if (item.clipped) {
+                    let mask;
+                    for (const child of item.children) {
+                        if (child.isClipMask()) {
+                            mask = child;
+                            break;
+                        }
+                    }
+                    item.clipped = false;
+                    mask.remove();
+                }
+
+                // Reduce single item nested in groups
+                if (item instanceof paper.Group && item.children.length === 1) {
+                    item = item.reduce();
+                }
+
+                ensureClockwise(item);
+                scaleWithStrokes(item, 2, new paper.Point()); // Import at 2x
+
+                if (typeof rotationCenterX !== 'undefined' && typeof rotationCenterY !== 'undefined') {
+                    let rotationPoint = new paper.Point(rotationCenterX, rotationCenterY);
+                    if (viewBox && viewBox.length >= 2 && !isNaN(viewBox[0]) && !isNaN(viewBox[1])) {
+                        rotationPoint = rotationPoint.subtract(viewBox[0], viewBox[1]);
+                    }
+                    item.translate(new paper.Point(ART_BOARD_WIDTH / 2, ART_BOARD_HEIGHT / 2)
+                        .subtract(rotationPoint.multiply(2)));
+                } else {
+                    // Center
+                    item.translate(new paper.Point(ART_BOARD_WIDTH / 2, ART_BOARD_HEIGHT / 2)
+                        .subtract(itemWidth, itemHeight));
+                }
+                if (isGroup(item)) {
+                    // Fixes an issue where we may export empty groups
+                    for (const child of item.children) {
+                        if (isGroup(child) && child.children.length === 0) {
+                            child.remove();
+                        }
+                    }
+                    ungroupItems([item]);
+                }
+
+                // Without the callback, the transforms sometimes don't finish applying before the
+                // snapshot is taken.
+                window.setTimeout(
+                    () => performSnapshot(paperCanvas.props.undoSnapshot, Formats.VECTOR_SKIP_CONVERT), 0);
             }
         });
-    }
-    initializeSvg (item, rotationCenterX, rotationCenterY, viewBox) {
-        const itemWidth = item.bounds.width;
-        const itemHeight = item.bounds.height;
-
-        // Remove viewbox
-        if (item.clipped) {
-            let mask;
-            for (const child of item.children) {
-                if (child.isClipMask()) {
-                    mask = child;
-                    break;
-                }
-            }
-            item.clipped = false;
-            mask.remove();
-        }
-
-        // Reduce single item nested in groups
-        if (item instanceof paper.Group && item.children.length === 1) {
-            item = item.reduce();
-        }
-
-        ensureClockwise(item);
-        scaleWithStrokes(item, 2, new paper.Point()); // Import at 2x
-
-        if (typeof rotationCenterX !== 'undefined' && typeof rotationCenterY !== 'undefined') {
-            let rotationPoint = new paper.Point(rotationCenterX, rotationCenterY);
-            if (viewBox && viewBox.length >= 2 && !isNaN(viewBox[0]) && !isNaN(viewBox[1])) {
-                rotationPoint = rotationPoint.subtract(viewBox[0], viewBox[1]);
-            }
-            item.translate(new paper.Point(ART_BOARD_WIDTH / 2, ART_BOARD_HEIGHT / 2)
-                .subtract(rotationPoint.multiply(2)));
-        } else {
-            // Center
-            item.translate(new paper.Point(ART_BOARD_WIDTH / 2, ART_BOARD_HEIGHT / 2)
-                .subtract(itemWidth, itemHeight));
-        }
-        paper.project.activeLayer.insertChild(0, item);
-        if (isGroup(item)) {
-            // Fixes an issue where we may export empty groups
-            for (const child of item.children) {
-                if (isGroup(child) && child.children.length === 0) {
-                    child.remove();
-                }
-            }
-            ungroupItems([item]);
-        }
-        performSnapshot(this.props.undoSnapshot, Formats.VECTOR_SKIP_CONVERT);
     }
     setCanvas (canvas) {
         this.canvas = canvas;


### PR DESCRIPTION
Reverts LLK/scratch-paint#755

@fsih this PR actually causes a few different issues when integrated with the GUI.

1. It breaks the "zoom to fit" functionality
2. It introduces a strange issue where reordering costumes can cause the reordered costume to inherit the contents of the previous costume. See this gif

![reorder-bug](https://user-images.githubusercontent.com/654102/48279909-017f3380-e420-11e8-9441-a17f7fa66bc2.gif)

I'm going to revert this PR so that we can deploy the GUI to beta without these fixes.