### PR TITLE
Update to paper with unsmoothed rasters

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git+ssh://git@github.com/LLK/scratch-paint.git"
   },
   "dependencies": {
-    "@scratch/paper": "0.11.20181029143421",
+    "@scratch/paper": "0.11.20181113220307",
     "classnames": "2.2.5",
     "keymirror": "0.1.1",
     "lodash.bindall": "4.4.0",


### PR DESCRIPTION
### Resolves
Closes https://github.com/LLK/scratch-paint/pull/759

### Proposed Changes
Update to paper version with unsmoothed rasters

### Reason for Changes
bitmap editor should have crisp pixels

### Test Coverage
Tested windows chrome, firefox, edge