### PR TITLE
Update scratch-l10n dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,25 @@ deploy:
 - provider: script
   on:
     all_branches: true
-    condition: $TRAVIS_BRANCH != develop
+    condition: $TRAVIS_BRANCH != develop && $TRAVIS_EVENT_TYPE != cron
   skip_cleanup: true
   script: npm run deploy -- -x -e $TRAVIS_BRANCH -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
 - provider: script
   on:
     branch: develop
+    condition: $TRAVIS_EVENT_TYPE != cron
   skip_cleanup: true
   script: npm run --silent deploy -- -x -a -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
 - provider: npm
   on:
     branch: develop
+    condition: $TRAVIS_EVENT_TYPE != cron
   skip_cleanup: true
   email: $NPM_EMAIL
   api_key: $NPM_TOKEN
+- provider: script
+  on:
+    branch: develop
+    condition: $TRAVIS_EVENT_TYPE == cron
+  skip_cleanup: true
+  script: npm run i18n:src && npm run i18n:push

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "npm run clean && webpack --progress --colors --bail",
     "clean": "rimraf ./dist && mkdirp dist && rimraf ./playground && mkdirp playground",
     "deploy": "touch playground/.nojekyll && gh-pages -t -d playground -m \"Build for $(git log --pretty=format:%H -n1)\"",
-    "i18n:src": "babel src > tmp.js && rimraf tmp.js && ./scripts/build-i18n-source.js ./translations/messages/ ./translations/",
+    "i18n:push": "tx-push-src scratch-editor paint-editor ./translations/en.json",
+    "i18n:src": "rimraf ./translations/messages && babel src > tmp.js && rimraf tmp.js && ./scripts/build-i18n-source.js ./translations/messages/ ./translations/",
     "lint": "eslint . --ext .js,.jsx",
     "start": "webpack-dev-server",
     "test": "npm run lint && npm run unit && NODE_ENV=production npm run build",
@@ -31,7 +32,6 @@
     "minilog": "3.1.0",
     "parse-color": "1.0.0",
     "prop-types": "^15.5.10",
-    "scratch-l10n": "^2.0.0",
     "scratch-svg-renderer": "0.2.0-prerelease.20181126212715"
   },
   "peerDependencies": {
@@ -90,6 +90,7 @@
     "redux-throttle": "0.1.1",
     "regenerator-runtime": "^0.12.0",
     "rimraf": "^2.6.1",
+    "scratch-l10n": "3.1.20181129221712",
     "style-loader": "^0.23.1",
     "svg-url-loader": "^2.3.2",
     "tap": "^11.1.0",

--- a/src/playground/reducers/intl.js
+++ b/src/playground/reducers/intl.js
@@ -3,7 +3,7 @@ import {updateIntl as superUpdateIntl} from 'react-intl-redux';
 import {IntlProvider, intlReducer} from 'react-intl-redux';
 
 import localeData from 'scratch-l10n';
-import paintMessages from 'scratch-l10n/locales/paint-msgs';
+import paintMessages from 'scratch-l10n/locales/paint-editor-msgs';
 
 Object.keys(localeData).forEach(locale => {
     // TODO: will need to handle locales not in the default intl - see www/custom-locales


### PR DESCRIPTION
- update to scratch-l10n that includes script for pushing new source file to transifex
- change the name of `paint-msgs` (change introduced with updating from l10n 2.x to 3.x)
- add travis job to build translation source (en.json) when running a cron job