### PR TITLE
Get proper paintMessages object properties

### DIFF
--- a/src/playground/reducers/intl.js
+++ b/src/playground/reducers/intl.js
@@ -14,13 +14,13 @@ const intlInitialState = {
     intl: {
         defaultLocale: 'en',
         locale: 'en',
-        messages: paintMessages.messages.en.messages
+        messages: paintMessages.en.messages
     }
 };
 
 const updateIntl = locale => superUpdateIntl({
     locale: locale,
-    messages: paintMessages.messages[locale].messages || paintMessages.messages.en.messages
+    messages: paintMessages[locale].messages || paintMessages.en.messages
 });
 
 export {


### PR DESCRIPTION
### Resolves

Resolves #784 (basically, https://llk.github.io/scratch-paint/ is currently broken)

### Proposed Changes

Change the paintMessages object properties so it doesn't give an error - it looks like #779 introduced this bug when updating to a new version of scratch-l10n
