### PR TITLE
Limit stroke width to 100

### DIFF
--- a/src/components/forms/input.css
+++ b/src/components/forms/input.css
@@ -45,11 +45,11 @@ Edited to add input-range-small
 }
 
 .input-small {
-    width: 3rem; 
+    width: 3rem;
     text-align: center;
 }
 
 .input-small-range {
-    width: 3.75rem;
+    width: 4rem;
     text-align: center;
 }

--- a/src/reducers/stroke-width.js
+++ b/src/reducers/stroke-width.js
@@ -3,7 +3,7 @@ import {CHANGE_SELECTED_ITEMS} from './selected-items';
 import {getColorsFromSelection} from '../helper/style-path';
 
 const CHANGE_STROKE_WIDTH = 'scratch-paint/stroke-width/CHANGE_STROKE_WIDTH';
-const MAX_STROKE_WIDTH = 800;
+const MAX_STROKE_WIDTH = 100;
 const initialState = 4;
 
 const reducer = function (state, action) {

--- a/test/unit/stroke-width-reducer.test.js
+++ b/test/unit/stroke-width-reducer.test.js
@@ -13,7 +13,7 @@ test('initialState', () => {
 
 test('changestrokeWidth', () => {
     let defaultState;
-    const newstrokeWidth = 234;
+    const newstrokeWidth = 23;
 
     expect(strokeWidthReducer(defaultState /* state */, changeStrokeWidth(newstrokeWidth) /* action */))
         .toEqual(newstrokeWidth);


### PR DESCRIPTION
### Resolves
Fixes https://github.com/LLK/scratch-paint/issues/768

### Proposed Changes
Change the max stroke width to 100
I also bumped up the size of the stroke input so that it doesn't show '...' when you type in 100

### Reason for Changes
Strokes do really weird things when they're thick

### Test Coverage

_Please show how you have added tests to cover your changes_