### PR TITLE
Make eyedropper work on touch, fix related bugs

### DIFF
--- a/src/components/loupe/loupe.jsx
+++ b/src/components/loupe/loupe.jsx
@@ -66,6 +66,11 @@ class LoupeComponent extends React.Component {
     }
     setCanvas (element) {
         this.canvas = element;
+        // Make sure to draw a frame when this component is first mounted
+        // Check for null ref because refs are called with null when unmounted
+        if (this.canvas) {
+            this.draw();
+        }
     }
     render () {
         const {

--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -78,6 +78,7 @@ class PaintEditor extends React.Component {
         bindAll(this, [
             'switchMode',
             'onMouseDown',
+            'onMouseUp',
             'setCanvas',
             'setTextArea',
             'startEyeDroppingLoop',
@@ -100,6 +101,8 @@ class PaintEditor extends React.Component {
         // canvas, and should therefore stop the eye dropper
         document.addEventListener('mousedown', this.onMouseDown);
         document.addEventListener('touchstart', this.onMouseDown);
+        document.addEventListener('mouseup', this.onMouseUp);
+        document.addEventListener('touchend', this.onMouseUp);
     }
     componentWillReceiveProps (newProps) {
         if (isVector(this.props.format) && isBitmap(newProps.format)) {
@@ -133,6 +136,8 @@ class PaintEditor extends React.Component {
         this.stopEyeDroppingLoop();
         document.removeEventListener('mousedown', this.onMouseDown);
         document.removeEventListener('touchstart', this.onMouseDown);
+        document.removeEventListener('mouseup', this.onMouseUp);
+        document.removeEventListener('touchend', this.onMouseUp);
     }
     switchMode (newFormat) {
         if (isVector(newFormat)) {
@@ -234,7 +239,8 @@ class PaintEditor extends React.Component {
             // Exit text edit mode if you click anywhere outside of canvas
             this.props.removeTextEditTarget();
         }
-
+    }
+    onMouseUp () {
         if (this.props.isEyeDropping) {
             const colorString = this.eyeDropper.colorString;
             const callback = this.props.changeColorToEyeDropper;

--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -117,7 +117,7 @@ class PaintEditor extends React.Component {
         } else if (!this.props.isEyeDropping && prevProps.isEyeDropping) {
             this.stopEyeDroppingLoop();
         } else if (this.props.isEyeDropping && this.props.viewBounds !== prevProps.viewBounds) {
-            this.props.previousTool.activate();
+            if (this.props.previousTool) this.props.previousTool.activate();
             this.props.onDeactivateEyeDropper();
             this.stopEyeDroppingLoop();
         }
@@ -245,7 +245,7 @@ class PaintEditor extends React.Component {
                 // so apply the new color
                 callback(colorString);
             }
-            this.props.previousTool.activate();
+            if (this.props.previousTool) this.props.previousTool.activate();
             this.props.onDeactivateEyeDropper();
             this.stopEyeDroppingLoop();
         }

--- a/src/helper/tools/eye-dropper.js
+++ b/src/helper/tools/eye-dropper.js
@@ -32,6 +32,7 @@ class EyeDropperTool extends paper.Tool {
         };
 
         this.onMouseDown = this.handleMouseDown;
+        this.onMouseUp = this.handleMouseUp;
         this.onMouseMove = this.handleMouseMove;
 
         this.canvas = canvas;
@@ -58,7 +59,13 @@ class EyeDropperTool extends paper.Tool {
             this.pickY > this.height ||
             this.pickY < 0;
     }
-    handleMouseDown () {
+    handleMouseDown (event) {
+        // Nothing special on mousedown, just send to move handler which will show the loupe,
+        // and the mouse up handler submits the color. This allows touch to drag
+        // with the loupe visible to find the correct color
+        this.handleMouseMove(event);
+    }
+    handleMouseUp () {
         if (!this.hideLoupe) {
             const colorInfo = this.getColorInfo(this.pickX, this.pickY, this.hideLoupe);
             if (!colorInfo) return;


### PR DESCRIPTION
Fixes an issue where you could not use the paint editor eye dropper on touch.

This was done by moving the eyedropper end callback from using mousedown to using mouseup, and make mousedown do the same thing as mousemove (i.e. hover). 

The effect of this is that touch devices can touch down, see the color, move and see the color change, then mouseup to finish. The non-touch experience is effectively the same, you can still hover to see colors and click to submit.

Existing hover action has not changed
![hover-loupe](https://user-images.githubusercontent.com/654102/51123142-70df1e00-17e9-11e9-9efb-6b0b4d24914a.gif)

But touch experience works better
![drag-loupe](https://user-images.githubusercontent.com/654102/51123147-75a3d200-17e9-11e9-9941-c3b1927646f3.gif)

Also fixed an  uncovered but with the loupe where it wouldn't draw the first time. Also includes a fix in an eyedropper-related line of code that was causing crashes reported from Sentry, where the code was assuming `previousTool` was not null.