### PR TITLE
End check for bounds at 0,0 instead of imageData.width, imageData.height

### DIFF
--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -329,10 +329,10 @@ const getHitBounds = function (raster) {
     let left = 0;
     let right = imageData.width;
 
-    while (top < bottom && rowBlank_(imageData, width, top)) ++top;
     while (bottom - 1 > top && rowBlank_(imageData, width, bottom - 1)) --bottom;
-    while (left < right && columnBlank_(imageData, width, left, top, bottom)) ++left;
+    while (top < bottom && rowBlank_(imageData, width, top)) ++top;
     while (right - 1 > left && columnBlank_(imageData, width, right - 1, top, bottom)) --right;
+    while (left < right && columnBlank_(imageData, width, left, top, bottom)) ++left;
 
     return new paper.Rectangle(left, top, right - left, bottom - top);
 };

--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -329,10 +329,10 @@ const getHitBounds = function (raster) {
     let left = 0;
     let right = imageData.width;
 
-    while (bottom - 1 > top && rowBlank_(imageData, width, bottom - 1)) --bottom;
     while (top < bottom && rowBlank_(imageData, width, top)) ++top;
-    while (right - 1 > left && columnBlank_(imageData, width, right - 1, top, bottom)) --right;
+    while (bottom - 1 > top && rowBlank_(imageData, width, bottom - 1)) --bottom;
     while (left < right && columnBlank_(imageData, width, left, top, bottom)) ++left;
+    while (right - 1 > left && columnBlank_(imageData, width, right - 1, top, bottom)) --right;
 
     return new paper.Rectangle(left, top, right - left, bottom - top);
 };

--- a/src/hocs/update-image-hoc.jsx
+++ b/src/hocs/update-image-hoc.jsx
@@ -89,9 +89,18 @@ const UpdateImageHOC = function (WrappedComponent) {
                 }
             }
             const rect = getHitBounds(plasteredRaster);
+            const imageData = plasteredRaster.getImageData(rect);
+
+            // If the bitmap has a zero width or height, save this information
+            // since zero isn't a valid value for on imageData objects' widths and heights.
+            if (rect.width === 0 || rect.height === 0) {
+                imageData.sourceWidth = rect.width;
+                imageData.sourceHeight = rect.height;
+            }
+
             this.props.onUpdateImage(
                 false /* isVector */,
-                plasteredRaster.getImageData(rect),
+                imageData,
                 (ART_BOARD_WIDTH / 2) - rect.x,
                 (ART_BOARD_HEIGHT / 2) - rect.y);
 


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-gui/issues/4409

### Proposed Changes

Invert the while loop order when checking for the bounds of a bitmap. This way we end our checks with an `x` and `y` value of 1. 

### Reason for Changes

Ending our bounds check at 0,0 will [pass 1,1 as the x and y values to calculate the skin's rotation center.](https://github.com/LLK/scratch-paint/blob/develop/src/hocs/update-image-hoc.jsx#L95-L96) Previously when the bitmap was empty, `getHitBounds` would get to the very bottom right corner of the imageData without finding a bound and would pass the bottom right coordinates (on my computer they were 960 and 720) as the x, y values for determining the rotation center, which [assumes the bound is at the top left of the image instead of the bottom right when it gets the image data.](https://github.com/paperjs/paper.js/blob/develop/src/item/Raster.js#L681)

By passing 1,1 as our x, y values for bitmaps without bounds, we are setting the rotation center as if our image's top left bound started near the top left of the stage, which sets the rotation center to be near the center of the stage, and allows the pen tool to draw on all parts of the stage. 

One thing that is tricky about this fix is that it only will fix the rotation center for existing projects if `getHitBounds` is run again. You can see this issue in [this project.](https://scratch.mit.edu/projects/284879849/) If you have the fix running locally and load this project, the pen tool will stay in the top left quadrant of the stage until you toggle between bitmap and vector for the empty bitmap skin. This isn't a problem for new projects.

### Test Coverage

I have an idea for how to test this, but I need to be able to create canvas images during the test. I tried `jest-canvas-mock` to mock canvas for the test, but it doesn't mock the image creating capability, so `getHitBounds` always finds the bitmap empty. I'm looking for a different option, but let me know if anyone has thoughts!