### PR TITLE
Change fill logic to prevent setting gradients by accident

### DIFF
--- a/src/helper/tools/fill-tool.js
+++ b/src/helper/tools/fill-tool.js
@@ -178,10 +178,12 @@ class FillTool extends paper.Tool {
     _setFillItemColor (color1, color2, gradientType, pointerLocation) {
         const item = this._getFillItem();
         if (!item) return;
-        if (color1 instanceof paper.Color || gradientType === GradientTypes.SOLID) {
-            item.fillColor = color1;
-        } else {
+        // Only create a gradient if specifically requested, else use color1 directly
+        // This ensures we do not set a gradient by accident (see scratch-paint#830).
+        if (gradientType && gradientType !== GradientTypes.SOLID) {
             item.fillColor = createGradientObject(color1, color2, gradientType, item.bounds, pointerLocation);
+        } else {
+            item.fillColor = color1;
         }
     }
     _getFillItem () {


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-paint/issues/639
Fixes https://github.com/LLK/scratch-paint/issues/830

### Proposed Changes

_Describe what this Pull Request does_

There was a bug in the method used to fill items when using the vector fill tool where items that had been transparent got set to an invalid gradient, causing them to show up as black.

### Reason for Changes

_Explain why these changes should be made_

Make the fill code more picky about when to generate gradients.

/cc @fsih 
