### PR TITLE
Pan/zoom with tool #401 #638

### DIFF
--- a/src/containers/scrollable-canvas.jsx
+++ b/src/containers/scrollable-canvas.jsx
@@ -113,7 +113,7 @@ class ScrollableCanvas extends React.Component {
             pan(dx, dy);
             this.props.updateViewBounds(paper.view.matrix);
             if (paper.tool) {
-                paper.tool.view._handleMouseEvent('mousemove', event, fixedPoint)
+                paper.tool.view._handleMouseEvent('mousemove', event, fixedPoint);
             }
         }
         event.preventDefault();

--- a/src/containers/scrollable-canvas.jsx
+++ b/src/containers/scrollable-canvas.jsx
@@ -89,14 +89,14 @@ class ScrollableCanvas extends React.Component {
         const multiplier = event.deltaMode === 0x1 ? 15 : 1;
         const deltaX = event.deltaX * multiplier;
         const deltaY = event.deltaY * multiplier;
+        const canvasRect = this.props.canvas.getBoundingClientRect();
+        const offsetX = event.clientX - canvasRect.left;
+        const offsetY = event.clientY - canvasRect.top;
+        const fixedPoint = paper.view.viewToProject(
+            new paper.Point(offsetX, offsetY)
+        );
         if (event.metaKey || event.ctrlKey) {
             // Zoom keeping mouse location fixed
-            const canvasRect = this.props.canvas.getBoundingClientRect();
-            const offsetX = event.clientX - canvasRect.left;
-            const offsetY = event.clientY - canvasRect.top;
-            const fixedPoint = paper.view.viewToProject(
-                new paper.Point(offsetX, offsetY)
-            );
             zoomOnFixedPoint(-deltaY / 1000, fixedPoint);
             this.props.updateViewBounds(paper.view.matrix);
             this.props.redrawSelectionBox(); // Selection handles need to be resized after zoom
@@ -112,6 +112,9 @@ class ScrollableCanvas extends React.Component {
             const dy = deltaY / paper.view.zoom;
             pan(dx, dy);
             this.props.updateViewBounds(paper.view.matrix);
+            if (paper.tool) {
+                paper.tool.view._handleMouseEvent('mousemove', event, fixedPoint)
+            }
         }
         event.preventDefault();
     }


### PR DESCRIPTION
### Resolves

#401 and #638 

### Proposed Changes

Emits one extra event so that panning also notifies drag/move of tool.

### Reason for Changes

Panning/zooming while using tool gives strange effects

### Test Coverage

See gifs in issues :-)