### PR TITLE
fix(package): update scratch-svg-renderer to version 0.2.0-prerelease…

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "minilog": "3.1.0",
     "parse-color": "1.0.0",
     "prop-types": "^15.5.10",
-    "scratch-svg-renderer": "0.2.0-prerelease.20181220183040"
+    "scratch-svg-renderer": "0.2.0-prerelease.20190419183947"
   },
   "peerDependencies": {
     "react": "^16",


### PR DESCRIPTION
….20190419183947

Closes #815