### PR TITLE
Add Rapa Nui to the wide locales

### DIFF
--- a/src/lib/hide-label.js
+++ b/src/lib/hide-label.js
@@ -14,6 +14,7 @@ const localeTooBig = [
     'ja-Hira',
     'nb',
     'nn',
+    'rap',
     'th',
     'sr',
     'sk',


### PR DESCRIPTION
Rapa Nui should show paint editor buttons without labels because they are too long to fit on small screens.

