### PR TITLE
When converting to bitmap, call inlineSvgFonts() on SVG string instead of SVG element

### DIFF
--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -379,8 +379,9 @@ const convertToBitmap = function (clearSelectedItems, onUpdateImage) {
     // Get rid of anti-aliasing
     // @todo get crisp text https://github.com/LLK/scratch-paint/issues/508
     svg.setAttribute('shape-rendering', 'crispEdges');
-    inlineSvgFonts(svg);
-    const svgString = (new XMLSerializer()).serializeToString(svg);
+
+    let svgString = (new XMLSerializer()).serializeToString(svg);
+    svgString = inlineSvgFonts(svgString);
 
     // Put anti-aliased SVG into image, and dump image back into canvas
     const img = new Image();


### PR DESCRIPTION
### Resolves

Resolves #841

### Proposed Changes

This changes the `convertToBitmap` function to pass the stringified SVG to `inlineSvgFonts()` instead of the SVG element.

### Reason for Changes

https://github.com/LLK/scratch-svg-renderer/pull/72 changed inlineSvgFonts() to operate on stringified SVGs, not SVG elements. It fails silently if given an SVG element--possibly something to look into changing as well?