### PR TITLE
Add hex input

### DIFF
--- a/src/components/color-picker/color-picker.css
+++ b/src/components/color-picker/color-picker.css
@@ -25,6 +25,10 @@
     justify-content: space-between;
 }
 
+.hex-input {
+    width: 7ch;
+}
+
 .row-header {
     font-family: "Helvetica Neue", Helvetica, sans-serif;
     font-size: 0.65rem;
@@ -59,13 +63,14 @@
 }
 
 .swatch {
-    width: 1.5rem;
-    height: 1.5rem;
+    width: 2rem;
+    height: 2rem;
     border: 1px solid #ddd;
     border-radius: 4px;
     box-sizing: content-box;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 .large-swatch-icon {

--- a/src/components/color-picker/color-picker.jsx
+++ b/src/components/color-picker/color-picker.jsx
@@ -284,7 +284,7 @@ class ColorPickerComponent extends React.Component {
                     <div className={classNames(styles.swatches, styles.hexSwatch)}>
                         <input
                             className={classNames(inputStyles.inputForm, styles.hexInput)}
-                            value={hsvToHex(this.props.hue, this.props.saturation, this.props.brightness)}
+                            value={this.props.hex}
                             onChange={this.handleHexChange}
                             onFocus={this.handleHexFocus}
                         />
@@ -317,6 +317,7 @@ ColorPickerComponent.propTypes = {
     color2: PropTypes.string,
     colorIndex: PropTypes.number.isRequired,
     gradientType: PropTypes.oneOf(Object.keys(GradientTypes)).isRequired,
+    hex: PropTypes.string.isRequired,
     hue: PropTypes.number.isRequired,
     intl: intlShape.isRequired,
     isEyeDropping: PropTypes.bool.isRequired,

--- a/src/components/color-picker/color-picker.jsx
+++ b/src/components/color-picker/color-picker.jsx
@@ -1,3 +1,4 @@
+import bindAll from 'lodash.bindall';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
@@ -35,6 +36,13 @@ const messages = defineMessages({
     }
 });
 class ColorPickerComponent extends React.Component {
+    constructor () {
+        super();
+        bindAll(this, [
+            'handleHexChange',
+            'handleHexFocus'
+        ]);
+    }
     _makeBackground (channel) {
         const stops = [];
         // Generate the color slider background CSS gradients by adding
@@ -55,6 +63,12 @@ class ColorPickerComponent extends React.Component {
             }
         }
         return `linear-gradient(to left, ${stops.join(',')})`;
+    }
+    handleHexChange (evt) {
+        this.props.onHexChange(evt.target.value);
+    }
+    handleHexFocus (evt) {
+        evt.target.select();
     }
     render () {
         return (
@@ -268,7 +282,12 @@ class ColorPickerComponent extends React.Component {
                         }
                     </div>
                     <div className={classNames(styles.swatches, styles.hexSwatch)}>
-                        <input className={classNames(inputStyles.inputForm, styles.hexInput)} />
+                        <input
+                            className={classNames(inputStyles.inputForm, styles.hexInput)}
+                            value={hsvToHex(this.props.hue, this.props.saturation, this.props.brightness)}
+                            onChange={this.handleHexChange}
+                            onFocus={this.handleHexFocus}
+                        />
                     </div>
                     <div className={styles.swatches}>
                         <div
@@ -308,6 +327,7 @@ ColorPickerComponent.propTypes = {
     onChangeGradientTypeRadial: PropTypes.func.isRequired,
     onChangeGradientTypeSolid: PropTypes.func.isRequired,
     onChangeGradientTypeVertical: PropTypes.func.isRequired,
+    onHexChange: PropTypes.func.isRequired,
     onHueChange: PropTypes.func.isRequired,
     onSaturationChange: PropTypes.func.isRequired,
     onSelectColor: PropTypes.func.isRequired,

--- a/src/components/color-picker/color-picker.jsx
+++ b/src/components/color-picker/color-picker.jsx
@@ -8,6 +8,7 @@ import parseColor from 'parse-color';
 import Slider from '../forms/slider.jsx';
 import LabeledIconButton from '../labeled-icon-button/labeled-icon-button.jsx';
 import styles from './color-picker.css';
+import inputStyles from '../forms/input.css';
 import GradientTypes from '../../lib/gradient-types';
 import {MIXED} from '../../helper/style-path';
 
@@ -265,6 +266,9 @@ class ColorPickerComponent extends React.Component {
                                 />
                             </div>)
                         }
+                    </div>
+                    <div className={classNames(styles.swatches, styles.hexSwatch)}>
+                        <input className={classNames(inputStyles.inputForm, styles.hexInput)} />
                     </div>
                     <div className={styles.swatches}>
                         <div

--- a/src/components/forms/slider.css
+++ b/src/components/forms/slider.css
@@ -1,7 +1,9 @@
 .container {
     margin: 8px;
     height: 22px;
-    width: 150px;
+    min-width: 150px;
+    flex-grow: 1;
+    box-sizing: border-box;
     position: relative;
     outline: none;
     border-radius: 11px;
@@ -12,10 +14,17 @@
     margin-bottom: 4px;
 }
 
+.handle-range {
+    margin-left: 13px;
+    margin-right: 13px;
+    position: relative;
+}
+
 .handle {
     left: 100px;
     width: 26px;
     height: 26px;
+    margin-left: -13px;
     margin-top: -2px;
     position: absolute;
     background-color: white;

--- a/src/components/forms/slider.jsx
+++ b/src/components/forms/slider.jsx
@@ -6,9 +6,6 @@ import {getEventXY} from '../../lib/touch-utils';
 
 import styles from './slider.css';
 
-const CONTAINER_WIDTH = 150;
-const HANDLE_WIDTH = 26;
-
 class SliderComponent extends React.Component {
     constructor (props) {
         super(props);
@@ -56,12 +53,7 @@ class SliderComponent extends React.Component {
     }
 
     render () {
-        const halfHandleWidth = HANDLE_WIDTH / 2;
-        const pixelMin = halfHandleWidth;
-        const pixelMax = CONTAINER_WIDTH - halfHandleWidth;
-        const handleOffset = pixelMin +
-            ((pixelMax - pixelMin) * (this.props.value / 100)) -
-            halfHandleWidth;
+        const handleOffset = this.props.value;
         return (
             <div
                 className={classNames({
@@ -74,14 +66,16 @@ class SliderComponent extends React.Component {
                 }}
                 onClick={this.handleClickBackground}
             >
-                <div
-                    className={styles.handle}
-                    style={{
-                        left: `${handleOffset}px`
-                    }}
-                    onMouseDown={this.handleMouseDown}
-                    onTouchStart={this.handleMouseDown}
-                />
+                <div className={classNames(styles.handleRange)}>
+                    <div
+                        className={styles.handle}
+                        style={{
+                            left: `${handleOffset}%`
+                        }}
+                        onMouseDown={this.handleMouseDown}
+                        onTouchStart={this.handleMouseDown}
+                    />
+                </div>
             </div>
         );
     }

--- a/src/containers/color-picker.jsx
+++ b/src/containers/color-picker.jsx
@@ -54,6 +54,7 @@ class ColorPicker extends React.Component {
         const color = props.colorIndex === 0 ? props.color : props.color2;
         const hsv = this.getHsv(color);
         this.state = {
+            hex: color.toLowerCase(),
             hue: hsv[0],
             saturation: hsv[1],
             brightness: hsv[2]
@@ -79,25 +80,38 @@ class ColorPicker extends React.Component {
             [50, 100, 100] : colorStringToHsv(color);
     }
     handleHexChange (hex) {
+        if (hex[0] !== '#') {
+            hex = `#${hex}`;
+        }
+        hex = hex.slice(0, 7).toLowerCase();
         if (parseColor(hex).hsv) {
             const [hue, saturation, brightness] = colorStringToHsv(hex);
-            this.setState({hue, saturation, brightness}, () => {
+            this.setState({hue, saturation, brightness, hex}, () => {
                 this.handleColorChange();
             });
         }
     }
     handleHueChange (hue) {
-        this.setState({hue: hue}, () => {
+        this.setState({
+            hue: hue,
+            hex: hsvToHex(hue, this.state.saturation, this.state.brightness)
+        }, () => {
             this.handleColorChange();
         });
     }
     handleSaturationChange (saturation) {
-        this.setState({saturation: saturation}, () => {
+        this.setState({
+            saturation: saturation,
+            hex: hsvToHex(this.state.hue, saturation, this.state.brightness)
+        }, () => {
             this.handleColorChange();
         });
     }
     handleBrightnessChange (brightness) {
-        this.setState({brightness: brightness}, () => {
+        this.setState({
+            brightness: brightness,
+            hex: hsvToHex(this.state.hue, this.state.saturation, brightness)
+        }, () => {
             this.handleColorChange();
         });
     }
@@ -137,6 +151,7 @@ class ColorPicker extends React.Component {
                 color2={this.props.color2}
                 colorIndex={this.props.colorIndex}
                 gradientType={this.props.gradientType}
+                hex={this.state.hex}
                 hue={this.state.hue}
                 isEyeDropping={this.props.isEyeDropping}
                 mode={this.props.mode}

--- a/src/containers/color-picker.jsx
+++ b/src/containers/color-picker.jsx
@@ -26,6 +26,8 @@ const colorStringToHsv = hexString => {
     return hsv;
 };
 
+const colorStringToHex = hexString => parseColor(hexString).hex;
+
 const hsvToHex = (h, s, v) =>
     // Scale hue back up to [0, 360] from [0, 100]
     parseColor(`hsv(${3.6 * h}, ${s}, ${v})`).hex
@@ -52,9 +54,10 @@ class ColorPicker extends React.Component {
         ]);
 
         const color = props.colorIndex === 0 ? props.color : props.color2;
+        const hex = this.getHex(color);
         const hsv = this.getHsv(color);
         this.state = {
-            hex: color.toLowerCase(),
+            hex: hex,
             hue: hsv[0],
             saturation: hsv[1],
             brightness: hsv[2]
@@ -78,6 +81,12 @@ class ColorPicker extends React.Component {
         const isMixed = color === MIXED;
         return isTransparent || isMixed ?
             [50, 100, 100] : colorStringToHsv(color);
+    }
+    getHex (color) {
+        const isTransparent = color === null;
+        const isMixed = color === MIXED;
+        return isTransparent || isMixed ?
+            hsvToHex(50, 100, 100) : colorStringToHex(color);
     }
     handleHexChange (hex) {
         if (hex[0] !== '#') {

--- a/src/containers/color-picker.jsx
+++ b/src/containers/color-picker.jsx
@@ -43,6 +43,7 @@ class ColorPicker extends React.Component {
             'handleChangeGradientTypeRadial',
             'handleChangeGradientTypeSolid',
             'handleChangeGradientTypeVertical',
+            'handleHexChange',
             'handleHueChange',
             'handleSaturationChange',
             'handleBrightnessChange',
@@ -76,6 +77,14 @@ class ColorPicker extends React.Component {
         const isMixed = color === MIXED;
         return isTransparent || isMixed ?
             [50, 100, 100] : colorStringToHsv(color);
+    }
+    handleHexChange (hex) {
+        if (parseColor(hex).hsv) {
+            const [hue, saturation, brightness] = colorStringToHsv(hex);
+            this.setState({hue, saturation, brightness}, () => {
+                this.handleColorChange();
+            });
+        }
     }
     handleHueChange (hue) {
         this.setState({hue: hue}, () => {
@@ -140,6 +149,7 @@ class ColorPicker extends React.Component {
                 onChangeGradientTypeRadial={this.handleChangeGradientTypeRadial}
                 onChangeGradientTypeSolid={this.handleChangeGradientTypeSolid}
                 onChangeGradientTypeVertical={this.handleChangeGradientTypeVertical}
+                onHexChange={this.handleHexChange}
                 onHueChange={this.handleHueChange}
                 onSaturationChange={this.handleSaturationChange}
                 onSelectColor={this.props.onSelectColor}


### PR DESCRIPTION
### Resolves

Resolves #69.

### Proposed Changes

1. Adds a hex input swatch, positioned between the transparent and eyedropper swatches. (https://github.com/LLK/scratch-paint/commit/afd933c872e664528f9820cf8510520a2363e918, https://github.com/LLK/scratch-paint/commit/47b50f7649d270e8a85a8929b716e64d4fd4b448)
    * It is exactly 7 characters wide, to make room for the full content of a `#123abc`-style string.
    * When clicked, it automatically selects the full content of the string.
    * Typing behavior is not well defined. It is meant to be used only for copying from and pasting to. (This is something that should be investigated, but I found messing around with the key-handling code to be rather a messy thing, especially whilst dealing with React.)
2. Changes the `<Slider>` element's code so that it does not rely on being a particular width. (https://github.com/LLK/scratch-paint/commit/bdd58e735d16293ef0eb2ae89c7b7651058ed9ba)
    * The width of the color picker is slightly greater and not strictly defined now, so the slider elements had to be adjusted to work at any width.
    * They still aim to be 150px+ but can be greater.
    * Constants were removed from the JS file (huzzah!), and the math was adjusted accordingly, offsetting the handle by a CSS-percentage of the container rather than an explicit number of pixels.
    * It controls exactly the same way it used to (stretched slightly). In order to keep the handle within the same range, an additional container had to be created, adding the 1/2-handle-width space on either end of the handle range.
3. Adds an additional state element to the color picker container: `hex`. (https://github.com/LLK/scratch-paint/commit/37eaf18395e01a2d8889e76605d2dc98acd4c315)
   * Although one would think this is redundant, it helps keep color precision tight - converting from hex to HSV and back tends to leave a small but noticeable change.

Edit: Screenshot below!

![The full color picker, with the new hex input swatch, set to the color of the orange in the Scratch logo.](https://user-images.githubusercontent.com/9948030/59208382-5eda8f00-8b7f-11e9-844c-43b9c09227e2.png)

### Reason for Changes

All the technical reasons are described above. As for the feature itself, it is a much-requested feature on the Scratch forums - see [this topic](https://scratch.mit.edu/discuss/topic/349418/) for example; here's [another much older one](https://scratch.mit.edu/discuss/topic/195758/). Both of those gathered an impressive amount of 'support'.

### Test Coverage

No new tests implemented here (tested manually). Maybe a good idea? I've never approached component tests before, though.