### PR TITLE
Fix dragging the whole page on iOS when using scrollbars

### DIFF
--- a/src/components/forms/slider.jsx
+++ b/src/components/forms/slider.jsx
@@ -24,14 +24,14 @@ class SliderComponent extends React.Component {
     handleMouseDown () {
         document.addEventListener('mousemove', this.handleMouseMove);
         document.addEventListener('mouseup', this.handleMouseUp);
-        document.addEventListener('touchmove', this.handleMouseMove);
+        document.addEventListener('touchmove', this.handleMouseMove, {passive: false});
         document.addEventListener('touchend', this.handleMouseUp);
     }
 
     handleMouseUp () {
         document.removeEventListener('mousemove', this.handleMouseMove);
         document.removeEventListener('mouseup', this.handleMouseUp);
-        document.removeEventListener('touchmove', this.handleMouseMove);
+        document.removeEventListener('touchmove', this.handleMouseMove, {passive: false});
         document.removeEventListener('touchend', this.handleMouseUp);
     }
 

--- a/src/containers/scrollable-canvas.jsx
+++ b/src/containers/scrollable-canvas.jsx
@@ -45,7 +45,7 @@ class ScrollableCanvas extends React.Component {
         this.initialMouseX = getEventXY(event).x;
         this.initialScreenX = paper.view.matrix.tx;
         window.addEventListener('mousemove', this.handleHorizontalScrollbarMouseMove);
-        window.addEventListener('touchmove', this.handleHorizontalScrollbarMouseMove);
+        window.addEventListener('touchmove', this.handleHorizontalScrollbarMouseMove, {passive: false});
         window.addEventListener('mouseup', this.handleHorizontalScrollbarMouseUp);
         window.addEventListener('touchend', this.handleHorizontalScrollbarMouseUp);
         event.preventDefault();
@@ -59,7 +59,7 @@ class ScrollableCanvas extends React.Component {
     }
     handleHorizontalScrollbarMouseUp () {
         window.removeEventListener('mousemove', this.handleHorizontalScrollbarMouseMove);
-        window.removeEventListener('touchmove', this.handleHorizontalScrollbarMouseMove);
+        window.removeEventListener('touchmove', this.handleHorizontalScrollbarMouseMove, {passive: false});
         window.removeEventListener('mouseup', this.handleHorizontalScrollbarMouseUp);
         window.removeEventListener('touchend', this.handleHorizontalScrollbarMouseUp);
         this.initialMouseX = null;
@@ -70,7 +70,7 @@ class ScrollableCanvas extends React.Component {
         this.initialMouseY = getEventXY(event).y;
         this.initialScreenY = paper.view.matrix.ty;
         window.addEventListener('mousemove', this.handleVerticalScrollbarMouseMove);
-        window.addEventListener('touchmove', this.handleVerticalScrollbarMouseMove);
+        window.addEventListener('touchmove', this.handleVerticalScrollbarMouseMove, {passive: false});
         window.addEventListener('mouseup', this.handleVerticalScrollbarMouseUp);
         window.addEventListener('touchend', this.handleVerticalScrollbarMouseUp);
         event.preventDefault();
@@ -84,7 +84,7 @@ class ScrollableCanvas extends React.Component {
     }
     handleVerticalScrollbarMouseUp (event) {
         window.removeEventListener('mousemove', this.handleVerticalScrollbarMouseMove);
-        window.removeEventListener('touchmove', this.handleVerticalScrollbarMouseMove);
+        window.removeEventListener('touchmove', this.handleVerticalScrollbarMouseMove, {passive: false});
         window.removeEventListener('mouseup', this.handleVerticalScrollbarMouseUp);
         window.removeEventListener('touchend', this.handleVerticalScrollbarMouseUp);
         this.initialMouseY = null;


### PR DESCRIPTION
Fixes an issue where dragging scrollbars or the sliders on iOS would result in the whole page moving around underneath the dragger. This is because you cannot preventDefault on a `touchmove` unless you specifically mark it as non-passive. 

This is the current behavior (made on the iOS simulator)
![dragging](https://user-images.githubusercontent.com/654102/60269195-fcda9300-98bb-11e9-9931-65f61a65f584.gif)

Here is the new behavior
![dragging-fixed](https://user-images.githubusercontent.com/654102/60269226-08c65500-98bc-11e9-83ba-e621f1e003ac.gif)
