### PR TITLE
Add no save and move back to node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ language: node_js
 sudo: required
 dist: trusty
 node_js:
-- 6
+- 8
 cache:
   directories:
   - node_modules
 install:
 - sudo apt-get update && sudo apt-get install -y libcairo2-dev libpango1.0-dev libssl-dev libjpeg62-dev libgif-dev pkg-config
-- npm install canvas@1.6.11
+- npm install --no-save canvas@1.6.11
 - npm --production=false install
 - npm --production=false update
 before_deploy:


### PR DESCRIPTION
no-save option should not add canvas to scratch paint's dependencies, which breaks gui's build when new scratch paint is pulled in