### PR TITLE
Add npm ignore that leaves dist in the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,19 @@
+# Mac OS
+.DS_Store
+
+# Testing
+/test
+
+# NPM
+/node_modules
+npm-*
+
+# Build
+playground/*
+
+# Editors
+/#*
+*~
+
+# generated translation files
+/translations


### PR DESCRIPTION
This should fix the distributable of scratch-paint.
When we switched to node 8, the npm deploy started omitting the dist/ folder, which defeats the purpose. This is because npm falls back to .gitignore if .npmignore is missing. Add .npmignore that matches .gitignore except that it does not omit dist or locale folders, and omits test/