### PR TITLE
Fix bitmap sprites opening with no default tool selected

### DIFF
--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -24,6 +24,7 @@ import {resetZoom, zoomOnSelection} from '../helper/view';
 import EyeDropperTool from '../helper/tools/eye-dropper';
 
 import Modes from '../lib/modes';
+import {BitmapModes} from '../lib/modes';
 import Formats from '../lib/format';
 import {isBitmap, isVector} from '../lib/format';
 import bindAll from 'lodash.bindall';
@@ -105,9 +106,9 @@ class PaintEditor extends React.Component {
         document.addEventListener('touchend', this.onMouseUp);
     }
     componentWillReceiveProps (newProps) {
-        if (isVector(this.props.format) && isBitmap(newProps.format)) {
+        if (!isBitmap(this.props.format) && isBitmap(newProps.format)) {
             this.switchMode(Formats.BITMAP);
-        } else if (isVector(newProps.format) && isBitmap(this.props.format)) {
+        } else if (!isVector(this.props.format) && isVector(newProps.format)) {
             this.switchMode(Formats.VECTOR);
         }
         if (newProps.rtl !== this.props.rtl) {
@@ -140,7 +141,7 @@ class PaintEditor extends React.Component {
         document.removeEventListener('touchend', this.onMouseUp);
     }
     switchMode (newFormat) {
-        if (isVector(newFormat)) {
+        if (isVector(newFormat) && (this.props.mode in BitmapModes)) {
             switch (this.props.mode) {
             case Modes.BIT_BRUSH:
                 this.props.changeMode(Modes.BRUSH);
@@ -170,7 +171,8 @@ class PaintEditor extends React.Component {
                 log.error(`Mode not handled: ${this.props.mode}`);
                 this.props.changeMode(Modes.BRUSH);
             }
-        } else if (isBitmap(newFormat)) {
+        } else if (isBitmap(newFormat) &&
+                (this.props.mode in Modes && !(this.props.mode in BitmapModes))) {
             switch (this.props.mode) {
             case Modes.BRUSH:
                 this.props.changeMode(Modes.BIT_BRUSH);
@@ -202,6 +204,9 @@ class PaintEditor extends React.Component {
                 log.error(`Mode not handled: ${this.props.mode}`);
                 this.props.changeMode(Modes.BIT_BRUSH);
             }
+        } else if (!(this.props.mode in Modes)) {
+            log.error(`Mode not handled: ${this.props.mode}`);
+            this.props.changeMode(Modes.BIT_BRUSH);
         }
     }
     handleZoomIn () {

--- a/src/lib/modes.js
+++ b/src/lib/modes.js
@@ -24,7 +24,7 @@ const bitmapModesObj = {
 };
 const VectorModes = keyMirror(vectorModesObj);
 const BitmapModes = keyMirror(bitmapModesObj);
-const Modes = keyMirror({...vectorModesObj, ...bitmapModesObj})
+const Modes = keyMirror({...vectorModesObj, ...bitmapModesObj});
 
 export {
     Modes as default,

--- a/src/lib/modes.js
+++ b/src/lib/modes.js
@@ -1,14 +1,6 @@
 import keyMirror from 'keymirror';
 
-const Modes = keyMirror({
-    BIT_BRUSH: null,
-    BIT_LINE: null,
-    BIT_OVAL: null,
-    BIT_RECT: null,
-    BIT_TEXT: null,
-    BIT_FILL: null,
-    BIT_ERASER: null,
-    BIT_SELECT: null,
+const vectorModesObj = {
     BRUSH: null,
     ERASER: null,
     LINE: null,
@@ -19,9 +11,8 @@ const Modes = keyMirror({
     RECT: null,
     ROUNDED_RECT: null,
     TEXT: null
-});
-
-const BitmapModes = keyMirror({
+};
+const bitmapModesObj = {
     BIT_BRUSH: null,
     BIT_LINE: null,
     BIT_OVAL: null,
@@ -30,9 +21,13 @@ const BitmapModes = keyMirror({
     BIT_FILL: null,
     BIT_ERASER: null,
     BIT_SELECT: null
-});
+};
+const VectorModes = keyMirror(vectorModesObj);
+const BitmapModes = keyMirror(bitmapModesObj);
+const Modes = keyMirror({...vectorModesObj, ...bitmapModesObj})
 
 export {
     Modes as default,
+    VectorModes,
     BitmapModes
 };


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/811

Set the tool correctly when the paint editor is opened on a bitmap sprite. The format starts off as null, and the mode starts off as SELECT