### PR TITLE
Fix use of eyedropper with color 2 of gradient

### DIFF
--- a/src/containers/fill-color-indicator.jsx
+++ b/src/containers/fill-color-indicator.jsx
@@ -79,9 +79,14 @@ class FillColorIndicator extends React.Component {
         this.props.onChangeGradientType(gradientType);
     }
     handleCloseFillColor () {
-        if (!this.props.isEyeDropping) {
-            this.props.onCloseFillColor();
-        }
+        // If the eyedropper is currently being used, don't
+        // close the fill color menu.
+        if (this.props.isEyeDropping) return;
+
+        // Otherwise, close the fill color menu and
+        // also reset the color index to indicate
+        // that `color1` is selected.
+        this.props.onCloseFillColor();
         this.props.onChangeColorIndex(0);
     }
     handleSwap () {


### PR DESCRIPTION
### Resolves

Resolves #861 

### Proposed Changes

Reorder code in `handleCloseFillColor` so that it does not reset the color index when the eyedropper is in use.

Previously, this code was correctly keeping the fill color menu open when the eye dropper was in use, but it was resetting the color index (the piece of redux state keeping track of which color in the gradient is currently selected) to `0` indicating that the first color in the gradient was selected. 

This was causing the bug in #861 where using the eyedropper on color2 of the gradient resulted in changing color1 instead.