### PR TITLE
Handle `null` colors in bitmap shape tools

### DIFF
--- a/src/helper/bit-tools/oval-tool.js
+++ b/src/helper/bit-tools/oval-tool.js
@@ -76,7 +76,8 @@ class OvalTool extends paper.Tool {
                 this.thickness = this.oval.strokeWidth;
             }
             this.filled = this.oval.strokeWidth === 0;
-            this.color = this.filled ? this.oval.fillColor.toCSS() : this.oval.strokeColor.toCSS();
+            const color = this.filled ? this.oval.fillColor : this.oval.strokeColor;
+            this.color = color ? color.toCSS() : null;
         } else if (this.oval && this.oval.isInserted() && !this.oval.selected) {
             // Oval got deselected
             this.commitOval();

--- a/src/helper/bit-tools/rect-tool.js
+++ b/src/helper/bit-tools/rect-tool.js
@@ -76,7 +76,8 @@ class RectTool extends paper.Tool {
                 this.thickness = this.rect.strokeWidth;
             }
             this.filled = this.rect.strokeWidth === 0;
-            this.color = this.filled ? this.rect.fillColor.toCSS() : this.rect.strokeColor.toCSS();
+            const color = this.filled ? this.rect.fillColor : this.rect.strokeColor;
+            this.color = color ? color.toCSS() : null;
         } else if (this.rect && this.rect.isInserted() && !this.rect.selected) {
             // Rectangle got deselected
             this.commitRect();

--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -748,9 +748,13 @@ const commitOvalToBitmap = function (oval, bitmap) {
     const radiusY = Math.abs(oval.size.height / 2);
     const context = bitmap.getContext('2d');
     const filled = oval.strokeWidth === 0;
-    context.fillStyle = filled ?
-        oval.fillColor && oval.fillColor.toCSS() : oval.strokeColor && oval.strokeColor.toCSS();
 
+    const canvasColor = filled ? oval.fillColor : oval.strokeColor;
+    // If the color is null (e.g. fully transparent/"no fill"), don't bother drawing anything,
+    // and especially don't try calling `toCSS` on it
+    if (!canvasColor) return;
+
+    context.fillStyle = canvasColor.toCSS();
     const drew = drawEllipse({
         position: oval.position,
         radiusX,
@@ -771,8 +775,13 @@ const commitRectToBitmap = function (rect, bitmap) {
     const tmpCanvas = createCanvas();
     const context = tmpCanvas.getContext('2d');
     const filled = rect.strokeWidth === 0;
-    context.fillStyle = filled ?
-        rect.fillColor && rect.fillColor.toCSS() : rect.strokeColor && rect.strokeColor.toCSS();
+
+    const canvasColor = filled ? rect.fillColor : rect.strokeColor;
+    // If the color is null (e.g. fully transparent/"no fill"), don't bother drawing anything,
+    // and especially don't try calling `toCSS` on it
+    if (!canvasColor) return;
+
+    context.fillStyle = canvasColor.toCSS();
     if (filled) {
         fillRect(rect, context);
     } else {


### PR DESCRIPTION
### Resolves

Resolves #836

### Proposed Changes

This PR:
1. Changes `RectTool.onSelectionChanged` and `OvalTool.onSelectionChanged` to set their `color` to `null` if the selected item's `color` is also `null`, instead of unconditionally calling the selected item's `color.toCSS` method (which will not exist if the color is `null`, causing an error to be thrown)
2. Changes `commitRectToBitmap` and `commitOvalToBitmap` to not draw anything if the `color` of the shape they're drawing is `null`

### Reason for Changes

1. fixes the crash when undoing the creation of a bitmap shape with no color
2. fixes such a shape appearing as black when clicked, whereas it should not appear at all