### PR TITLE
Combine most `OvalTool` and `RectTool` functionality into `ShapeTool`

### DIFF
--- a/src/helper/bit-tools/oval-tool.js
+++ b/src/helper/bit-tools/oval-tool.js
@@ -1,19 +1,12 @@
 import paper from '@scratch/paper';
 import Modes from '../../lib/modes';
+import ShapeTool from './shape-tool';
 import {commitOvalToBitmap} from '../bitmap';
-import {getRaster} from '../layer';
-import {clearSelection} from '../selection';
-import {getSquareDimensions} from '../math';
-import BoundingBoxTool from '../selection-tools/bounding-box-tool';
-import NudgeTool from '../selection-tools/nudge-tool';
 
 /**
  * Tool for drawing ovals.
  */
-class OvalTool extends paper.Tool {
-    static get TOLERANCE () {
-        return 2;
-    }
+class OvalTool extends ShapeTool {
     /**
      * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
      * @param {function} clearSelectedItems Callback to clear the set of selected items in the Redux state
@@ -21,198 +14,10 @@ class OvalTool extends paper.Tool {
      * @param {!function} onUpdateImage A callback to call when the image visibly changes
      */
     constructor (setSelectedItems, clearSelectedItems, setCursor, onUpdateImage) {
-        super();
-        this.setSelectedItems = setSelectedItems;
-        this.clearSelectedItems = clearSelectedItems;
-        this.onUpdateImage = onUpdateImage;
-        this.boundingBoxTool = new BoundingBoxTool(
-            Modes.BIT_OVAL,
-            setSelectedItems,
-            clearSelectedItems,
-            setCursor,
-            onUpdateImage
-        );
-        const nudgeTool = new NudgeTool(this.boundingBoxTool, onUpdateImage);
+        super(setSelectedItems, clearSelectedItems, setCursor, onUpdateImage, Modes.BIT_OVAL);
 
-        // We have to set these functions instead of just declaring them because
-        // paper.js tools hook up the listeners in the setter functions.
-        this.onMouseDown = this.handleMouseDown;
-        this.onMouseDrag = this.handleMouseDrag;
-        this.onMouseMove = this.handleMouseMove;
-        this.onMouseUp = this.handleMouseUp;
-        this.onKeyUp = nudgeTool.onKeyUp;
-        this.onKeyDown = nudgeTool.onKeyDown;
-
-        this.oval = null;
-        this.color = null;
-        this.active = false;
-    }
-    getHitOptions () {
-        return {
-            segments: false,
-            stroke: true,
-            curves: false,
-            fill: true,
-            guide: false,
-            match: hitResult =>
-                (hitResult.item.data && (hitResult.item.data.isScaleHandle || hitResult.item.data.isRotHandle)) ||
-                hitResult.item.selected, // Allow hits on bounding box and selected only
-            tolerance: OvalTool.TOLERANCE / paper.view.zoom
-        };
-    }
-    /**
-     * Should be called if the selection changes to update the bounds of the bounding box.
-     * @param {Array<paper.Item>} selectedItems Array of selected items.
-     */
-    onSelectionChanged (selectedItems) {
-        this.boundingBoxTool.onSelectionChanged(selectedItems);
-        if ((!this.oval || !this.oval.isInserted()) &&
-                selectedItems && selectedItems.length === 1 && selectedItems[0].shape === 'ellipse') {
-            // Infer that an undo occurred and get back the active oval
-            this.oval = selectedItems[0];
-            if (this.oval.data.zoomLevel !== paper.view.zoom) {
-                this.oval.strokeWidth = this.oval.strokeWidth / this.oval.data.zoomLevel * paper.view.zoom;
-                this.oval.data.zoomLevel = paper.view.zoom;
-                this.thickness = this.oval.strokeWidth;
-            }
-            this.filled = this.oval.strokeWidth === 0;
-            const color = this.filled ? this.oval.fillColor : this.oval.strokeColor;
-            this.color = color ? color.toCSS() : null;
-        } else if (this.oval && this.oval.isInserted() && !this.oval.selected) {
-            // Oval got deselected
-            this.commitOval();
-        }
-    }
-    setColor (color) {
-        this.color = color;
-        if (this.oval) {
-            if (this.filled) {
-                this.oval.fillColor = this.color;
-            } else {
-                this.oval.strokeColor = this.color;
-            }
-        }
-    }
-    setFilled (filled) {
-        if (this.filled === filled) return;
-        this.filled = filled;
-        if (this.oval && this.oval.isInserted()) {
-            if (this.filled) {
-                this.oval.fillColor = this.color;
-                this.oval.strokeWidth = 0;
-                this.oval.strokeColor = null;
-            } else {
-                this.oval.fillColor = null;
-                this.oval.strokeWidth = this.thickness;
-                this.oval.strokeColor = this.color;
-            }
-            this.onUpdateImage();
-        }
-    }
-    setThickness (thickness) {
-        if (this.thickness === thickness * paper.view.zoom) return;
-        this.thickness = thickness * paper.view.zoom;
-        if (this.oval && this.oval.isInserted() && !this.filled) {
-            this.oval.strokeWidth = this.thickness;
-        }
-        if (this.oval && this.oval.isInserted()) {
-            this.oval.data.zoomLevel = paper.view.zoom;
-            this.onUpdateImage();
-        }
-    }
-    handleMouseDown (event) {
-        if (event.event.button > 0) return; // only first mouse button
-        this.active = true;
-
-        if (this.boundingBoxTool.onMouseDown(
-            event, false /* clone */, false /* multiselect */, false /* doubleClicked */, this.getHitOptions())) {
-            this.isBoundingBoxMode = true;
-        } else {
-            this.isBoundingBoxMode = false;
-            clearSelection(this.clearSelectedItems);
-            this.commitOval();
-            if (this.filled) {
-                this.oval = new paper.Shape.Ellipse({
-                    fillColor: this.color,
-                    point: event.downPoint,
-                    strokeWidth: 0,
-                    strokeScaling: false,
-                    size: 0
-                });
-            } else {
-                this.oval = new paper.Shape.Ellipse({
-                    strokeColor: this.color,
-                    strokeWidth: this.thickness,
-                    point: event.downPoint,
-                    strokeScaling: false,
-                    size: 0
-                });
-            }
-            this.oval.data = {zoomLevel: paper.view.zoom};
-        }
-    }
-    handleMouseDrag (event) {
-        if (event.event.button > 0 || !this.active) return; // only first mouse button
-
-        if (this.isBoundingBoxMode) {
-            this.boundingBoxTool.onMouseDrag(event);
-            return;
-        }
-
-        const downPoint = new paper.Point(event.downPoint.x, event.downPoint.y);
-        const point = new paper.Point(event.point.x, event.point.y);
-        const squareDimensions = getSquareDimensions(event.downPoint, event.point);
-        if (event.modifiers.shift) {
-            this.oval.size = squareDimensions.size.abs();
-        } else {
-            this.oval.size = downPoint.subtract(point);
-        }
-
-        if (event.modifiers.alt) {
-            this.oval.position = downPoint;
-        } else if (event.modifiers.shift) {
-            this.oval.position = squareDimensions.position;
-        } else {
-            this.oval.position = downPoint.subtract(this.oval.size.multiply(0.5));
-        }
-    }
-    handleMouseMove (event) {
-        this.boundingBoxTool.onMouseMove(event, this.getHitOptions());
-    }
-    handleMouseUp (event) {
-        if (event.event.button > 0 || !this.active) return; // only first mouse button
-
-        if (this.isBoundingBoxMode) {
-            this.boundingBoxTool.onMouseUp(event);
-            this.isBoundingBoxMode = null;
-            return;
-        }
-
-        if (this.oval) {
-            if (Math.abs(this.oval.size.width * this.oval.size.height) < OvalTool.TOLERANCE / paper.view.zoom) {
-                // Tiny oval created unintentionally?
-                this.oval.remove();
-                this.oval = null;
-            } else {
-                // Hit testing does not work correctly unless the width and height are positive
-                this.oval.size = new paper.Point(Math.abs(this.oval.size.width), Math.abs(this.oval.size.height));
-                this.oval.selected = true;
-                this.setSelectedItems();
-            }
-        }
-        this.active = false;
-        this.onUpdateImage();
-    }
-    commitOval () {
-        if (!this.oval || !this.oval.isInserted()) return;
-
-        commitOvalToBitmap(this.oval, getRaster());
-        this.oval.remove();
-        this.oval = null;
-    }
-    deactivateTool () {
-        this.commitOval();
-        this.boundingBoxTool.deactivateTool();
+        this.shapeConstructor = paper.Shape.Ellipse;
+        this.shapeCommitFunction = commitOvalToBitmap;
     }
 }
 

--- a/src/helper/bit-tools/rect-tool.js
+++ b/src/helper/bit-tools/rect-tool.js
@@ -1,19 +1,12 @@
 import paper from '@scratch/paper';
 import Modes from '../../lib/modes';
+import ShapeTool from './shape-tool';
 import {commitRectToBitmap} from '../bitmap';
-import {getRaster} from '../layer';
-import {clearSelection} from '../selection';
-import {getSquareDimensions} from '../math';
-import BoundingBoxTool from '../selection-tools/bounding-box-tool';
-import NudgeTool from '../selection-tools/nudge-tool';
 
 /**
  * Tool for drawing rects.
  */
-class RectTool extends paper.Tool {
-    static get TOLERANCE () {
-        return 2;
-    }
+class RectTool extends ShapeTool {
     /**
      * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
      * @param {function} clearSelectedItems Callback to clear the set of selected items in the Redux state
@@ -21,192 +14,10 @@ class RectTool extends paper.Tool {
      * @param {!function} onUpdateImage A callback to call when the image visibly changes
      */
     constructor (setSelectedItems, clearSelectedItems, setCursor, onUpdateImage) {
-        super();
-        this.setSelectedItems = setSelectedItems;
-        this.clearSelectedItems = clearSelectedItems;
-        this.onUpdateImage = onUpdateImage;
-        this.boundingBoxTool = new BoundingBoxTool(
-            Modes.BIT_RECT,
-            setSelectedItems,
-            clearSelectedItems,
-            setCursor,
-            onUpdateImage
-        );
-        const nudgeTool = new NudgeTool(this.boundingBoxTool, onUpdateImage);
+        super(setSelectedItems, clearSelectedItems, setCursor, onUpdateImage, Modes.BIT_OVAL);
 
-        // We have to set these functions instead of just declaring them because
-        // paper.js tools hook up the listeners in the setter functions.
-        this.onMouseDown = this.handleMouseDown;
-        this.onMouseDrag = this.handleMouseDrag;
-        this.onMouseMove = this.handleMouseMove;
-        this.onMouseUp = this.handleMouseUp;
-        this.onKeyUp = nudgeTool.onKeyUp;
-        this.onKeyDown = nudgeTool.onKeyDown;
-
-        this.rect = null;
-        this.color = null;
-        this.active = false;
-    }
-    getHitOptions () {
-        return {
-            segments: false,
-            stroke: true,
-            curves: false,
-            fill: true,
-            guide: false,
-            match: hitResult =>
-                (hitResult.item.data && (hitResult.item.data.isScaleHandle || hitResult.item.data.isRotHandle)) ||
-                hitResult.item.selected, // Allow hits on bounding box and selected only
-            tolerance: RectTool.TOLERANCE / paper.view.zoom
-        };
-    }
-    /**
-     * Should be called if the selection changes to update the bounds of the bounding box.
-     * @param {Array<paper.Item>} selectedItems Array of selected items.
-     */
-    onSelectionChanged (selectedItems) {
-        this.boundingBoxTool.onSelectionChanged(selectedItems);
-        if ((!this.rect || !this.rect.isInserted()) &&
-                selectedItems && selectedItems.length === 1 && selectedItems[0].shape === 'rectangle') {
-            // Infer that an undo occurred and get back the active rect
-            this.rect = selectedItems[0];
-            if (this.rect.data.zoomLevel !== paper.view.zoom) {
-                this.rect.strokeWidth = this.rect.strokeWidth / this.rect.data.zoomLevel * paper.view.zoom;
-                this.rect.data.zoomLevel = paper.view.zoom;
-                this.thickness = this.rect.strokeWidth;
-            }
-            this.filled = this.rect.strokeWidth === 0;
-            const color = this.filled ? this.rect.fillColor : this.rect.strokeColor;
-            this.color = color ? color.toCSS() : null;
-        } else if (this.rect && this.rect.isInserted() && !this.rect.selected) {
-            // Rectangle got deselected
-            this.commitRect();
-        }
-    }
-    setColor (color) {
-        this.color = color;
-        if (this.rect) {
-            if (this.filled) {
-                this.rect.fillColor = this.color;
-            } else {
-                this.rect.strokeColor = this.color;
-            }
-        }
-    }
-    setFilled (filled) {
-        if (this.filled === filled) return;
-        this.filled = filled;
-        if (this.rect && this.rect.isInserted()) {
-            if (this.filled) {
-                this.rect.fillColor = this.color;
-                this.rect.strokeWidth = 0;
-                this.rect.strokeColor = null;
-            } else {
-                this.rect.fillColor = null;
-                this.rect.strokeWidth = this.thickness;
-                this.rect.strokeColor = this.color;
-            }
-            this.onUpdateImage();
-        }
-    }
-    setThickness (thickness) {
-        if (this.thickness === thickness * paper.view.zoom) return;
-        this.thickness = thickness * paper.view.zoom;
-        if (this.rect && this.rect.isInserted() && !this.filled) {
-            this.rect.strokeWidth = this.thickness;
-        }
-        if (this.rect && this.rect.isInserted()) {
-            this.rect.data.zoomLevel = paper.view.zoom;
-            this.onUpdateImage();
-        }
-    }
-    handleMouseDown (event) {
-        if (event.event.button > 0) return; // only first mouse button
-        this.active = true;
-
-        if (this.boundingBoxTool.onMouseDown(
-            event, false /* clone */, false /* multiselect */, false /* doubleClicked */, this.getHitOptions())) {
-            this.isBoundingBoxMode = true;
-        } else {
-            this.isBoundingBoxMode = false;
-            clearSelection(this.clearSelectedItems);
-            this.commitRect();
-        }
-    }
-    handleMouseDrag (event) {
-        if (event.event.button > 0 || !this.active) return; // only first mouse button
-
-        if (this.isBoundingBoxMode) {
-            this.boundingBoxTool.onMouseDrag(event);
-            return;
-        }
-
-        const dimensions = event.point.subtract(event.downPoint);
-        const baseRect = new paper.Rectangle(event.downPoint, event.point);
-        const squareDimensions = getSquareDimensions(event.downPoint, event.point);
-        if (event.modifiers.shift) {
-            baseRect.size = squareDimensions.size.abs();
-        }
-
-        if (this.rect) this.rect.remove();
-        this.rect = new paper.Shape.Rectangle(baseRect);
-        if (this.filled) {
-            this.rect.fillColor = this.color;
-            this.rect.strokeWidth = 0;
-        } else {
-            this.rect.strokeColor = this.color;
-            this.rect.strokeWidth = this.thickness;
-        }
-        this.rect.strokeJoin = 'round';
-        this.rect.strokeScaling = false;
-        this.rect.data = {zoomLevel: paper.view.zoom};
-
-        if (event.modifiers.alt) {
-            this.rect.position = event.downPoint;
-        } else if (event.modifiers.shift) {
-            this.rect.position = squareDimensions.position;
-        } else {
-            this.rect.position = event.downPoint.add(dimensions.multiply(.5));
-        }
-    }
-    handleMouseMove (event) {
-        this.boundingBoxTool.onMouseMove(event, this.getHitOptions());
-    }
-    handleMouseUp (event) {
-        if (event.event.button > 0 || !this.active) return; // only first mouse button
-
-        if (this.isBoundingBoxMode) {
-            this.boundingBoxTool.onMouseUp(event);
-            this.isBoundingBoxMode = null;
-            return;
-        }
-
-        if (this.rect) {
-            if (Math.abs(this.rect.size.width * this.rect.size.height) < RectTool.TOLERANCE / paper.view.zoom) {
-                // Tiny shape created unintentionally?
-                this.rect.remove();
-                this.rect = null;
-            } else {
-                // Hit testing does not work correctly unless the width and height are positive
-                this.rect.size = new paper.Point(Math.abs(this.rect.size.width), Math.abs(this.rect.size.height));
-                this.rect.selected = true;
-                this.setSelectedItems();
-            }
-        }
-        this.active = false;
-        this.onUpdateImage();
-    }
-    commitRect () {
-        if (!this.rect || !this.rect.isInserted()) return;
-
-        commitRectToBitmap(this.rect, getRaster());
-
-        this.rect.remove();
-        this.rect = null;
-    }
-    deactivateTool () {
-        this.commitRect();
-        this.boundingBoxTool.deactivateTool();
+        this.shapeConstructor = paper.Shape.Rectangle;
+        this.shapeCommitFunction = commitRectToBitmap;
     }
 }
 

--- a/src/helper/bit-tools/shape-tool.js
+++ b/src/helper/bit-tools/shape-tool.js
@@ -1,0 +1,222 @@
+import paper from '@scratch/paper';
+import {getRaster} from '../layer';
+import {clearSelection} from '../selection';
+import {getSquareDimensions} from '../math';
+import BoundingBoxTool from '../selection-tools/bounding-box-tool';
+import NudgeTool from '../selection-tools/nudge-tool';
+
+/**
+ * Tool for drawing shapes (e.g. rectangles and ovals).
+ */
+class ShapeTool extends paper.Tool {
+    static get TOLERANCE () {
+        return 2;
+    }
+    /**
+     * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
+     * @param {function} clearSelectedItems Callback to clear the set of selected items in the Redux state
+     * @param {function} setCursor Callback to set the visible mouse cursor
+     * @param {!function} onUpdateImage A callback to call when the image visibly changes
+     * @param {BitmapModes} mode This tool's "mode"
+     */
+    constructor (setSelectedItems, clearSelectedItems, setCursor, onUpdateImage, mode) {
+        super();
+        this.setSelectedItems = setSelectedItems;
+        this.clearSelectedItems = clearSelectedItems;
+        this.onUpdateImage = onUpdateImage;
+        this.boundingBoxTool = new BoundingBoxTool(
+            mode,
+            setSelectedItems,
+            clearSelectedItems,
+            setCursor,
+            onUpdateImage
+        );
+        const nudgeTool = new NudgeTool(this.boundingBoxTool, onUpdateImage);
+
+        // We have to set these functions instead of just declaring them because
+        // paper.js tools hook up the listeners in the setter functions.
+        this.onMouseDown = this.handleMouseDown;
+        this.onMouseDrag = this.handleMouseDrag;
+        this.onMouseMove = this.handleMouseMove;
+        this.onMouseUp = this.handleMouseUp;
+        this.onKeyUp = nudgeTool.onKeyUp;
+        this.onKeyDown = nudgeTool.onKeyDown;
+
+        this.shape = null;
+        this.shapeType = null;
+        this.color = null;
+        this.active = false;
+    }
+    getHitOptions () {
+        return {
+            segments: false,
+            stroke: true,
+            curves: false,
+            fill: true,
+            guide: false,
+            match: hitResult =>
+                (hitResult.item.data && (hitResult.item.data.isScaleHandle || hitResult.item.data.isRotHandle)) ||
+                hitResult.item.selected, // Allow hits on bounding box and selected only
+            tolerance: ShapeTool.TOLERANCE / paper.view.zoom
+        };
+    }
+    /**
+     * Should be called if the selection changes to update the bounds of the bounding box.
+     * @param {Array<paper.Item>} selectedItems Array of selected items.
+     */
+    onSelectionChanged (selectedItems) {
+        this.boundingBoxTool.onSelectionChanged(selectedItems);
+        if ((!this.shape || !this.shape.isInserted()) &&
+                selectedItems && selectedItems.length === 1 && selectedItems[0].shape === this.shapeType) {
+            // Infer that an undo occurred and get back the active shape
+            this.shape = selectedItems[0];
+            if (this.shape.data.zoomLevel !== paper.view.zoom) {
+                this.shape.strokeWidth = this.shape.strokeWidth / this.shape.data.zoomLevel * paper.view.zoom;
+                this.shape.data.zoomLevel = paper.view.zoom;
+                this.thickness = this.shape.strokeWidth;
+            }
+            this.filled = this.shape.strokeWidth === 0;
+            const color = this.filled ? this.shape.fillColor : this.shape.strokeColor;
+            this.color = color ? color.toCSS() : null;
+        } else if (this.shape && this.shape.isInserted() && !this.shape.selected) {
+            // Shape got deselected
+            this.commitShape();
+        }
+    }
+    setColor (color) {
+        this.color = color;
+        if (this.shape) {
+            if (this.filled) {
+                this.shape.fillColor = this.color;
+            } else {
+                this.shape.strokeColor = this.color;
+            }
+        }
+    }
+    setFilled (filled) {
+        if (this.filled === filled) return;
+        this.filled = filled;
+        if (this.shape && this.shape.isInserted()) {
+            if (this.filled) {
+                this.shape.fillColor = this.color;
+                this.shape.strokeWidth = 0;
+                this.shape.strokeColor = null;
+            } else {
+                this.shape.fillColor = null;
+                this.shape.strokeWidth = this.thickness;
+                this.shape.strokeColor = this.color;
+            }
+            this.onUpdateImage();
+        }
+    }
+    setThickness (thickness) {
+        if (this.thickness === thickness * paper.view.zoom) return;
+        this.thickness = thickness * paper.view.zoom;
+        if (this.shape && this.shape.isInserted() && !this.filled) {
+            this.shape.strokeWidth = this.thickness;
+        }
+        if (this.shape && this.shape.isInserted()) {
+            this.shape.data.zoomLevel = paper.view.zoom;
+            this.onUpdateImage();
+        }
+    }
+    handleMouseDown (event) {
+        if (event.event.button > 0) return; // only first mouse button
+        this.active = true;
+
+        if (this.boundingBoxTool.onMouseDown(
+            event, false /* clone */, false /* multiselect */, false /* doubleClicked */, this.getHitOptions())) {
+            this.isBoundingBoxMode = true;
+        } else {
+            this.isBoundingBoxMode = false;
+            clearSelection(this.clearSelectedItems);
+            this.commitShape();
+
+            const shapeOptions = {
+                point: event.downPoint,
+                strokeScaling: false,
+                size: 0,
+                strokeJoin: 'round'
+            };
+
+            if (this.filled) {
+                shapeOptions.fillColor = this.color;
+                shapeOptions.strokeWidth = 0;
+            } else {
+                shapeOptions.strokeColor = this.color;
+                shapeOptions.strokeWidth = this.thickness;
+            }
+
+            this.shape = new this.shapeConstructor(shapeOptions);
+            this.shapeType = this.shape.type;
+            this.shape.data = {zoomLevel: paper.view.zoom};
+        }
+    }
+    handleMouseDrag (event) {
+        if (event.event.button > 0 || !this.active) return; // only first mouse button
+
+        if (this.isBoundingBoxMode) {
+            this.boundingBoxTool.onMouseDrag(event);
+            return;
+        }
+
+        const downPoint = new paper.Point(event.downPoint.x, event.downPoint.y);
+        const point = new paper.Point(event.point.x, event.point.y);
+        const squareDimensions = getSquareDimensions(event.downPoint, event.point);
+        const realSize = downPoint.subtract(point);
+        if (event.modifiers.shift) {
+            this.shape.size = squareDimensions.size.abs();
+        } else {
+            // Setting a negative size messes up the shape's radius, so keep it positive.
+            this.shape.size = realSize.abs();
+        }
+
+        if (event.modifiers.alt) {
+            this.shape.position = downPoint;
+        } else if (event.modifiers.shift) {
+            this.shape.position = squareDimensions.position;
+        } else {
+            this.shape.position = downPoint.subtract(realSize.multiply(0.5));
+        }
+    }
+    handleMouseMove (event) {
+        this.boundingBoxTool.onMouseMove(event, this.getHitOptions());
+    }
+    handleMouseUp (event) {
+        if (event.event.button > 0 || !this.active) return; // only first mouse button
+
+        if (this.isBoundingBoxMode) {
+            this.boundingBoxTool.onMouseUp(event);
+            this.isBoundingBoxMode = null;
+            return;
+        }
+
+        if (this.shape) {
+            if (Math.abs(this.shape.size.width * this.shape.size.height) < ShapeTool.TOLERANCE / paper.view.zoom) {
+                // Tiny shape created unintentionally?
+                this.shape.remove();
+                this.shape = null;
+            } else {
+                // Hit testing does not work correctly unless the width and height are positive
+                this.shape.size = new paper.Point(Math.abs(this.shape.size.width), Math.abs(this.shape.size.height));
+                this.shape.selected = true;
+                this.setSelectedItems();
+            }
+        }
+        this.active = false;
+        this.onUpdateImage();
+    }
+    commitShape () {
+        if (!this.shape || !this.shape.isInserted()) return;
+
+        this.shapeCommitFunction(this.shape, getRaster());
+        this.shape.remove();
+        this.shape = null;
+    }
+    deactivateTool () {
+        this.commitShape();
+        this.boundingBoxTool.deactivateTool();
+    }
+}
+
+export default ShapeTool;

--- a/src/helper/tools/oval-tool.js
+++ b/src/helper/tools/oval-tool.js
@@ -1,18 +1,11 @@
 import paper from '@scratch/paper';
 import Modes from '../../lib/modes';
-import {styleShape} from '../style-path';
-import {clearSelection} from '../selection';
-import {getSquareDimensions} from '../math';
-import BoundingBoxTool from '../selection-tools/bounding-box-tool';
-import NudgeTool from '../selection-tools/nudge-tool';
+import ShapeTool from './shape-tool';
 
 /**
  * Tool for drawing ovals.
  */
-class OvalTool extends paper.Tool {
-    static get TOLERANCE () {
-        return 2;
-    }
+class OvalTool extends ShapeTool {
     /**
      * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
      * @param {function} clearSelectedItems Callback to clear the set of selected items in the Redux state
@@ -20,129 +13,9 @@ class OvalTool extends paper.Tool {
      * @param {!function} onUpdateImage A callback to call when the image visibly changes
      */
     constructor (setSelectedItems, clearSelectedItems, setCursor, onUpdateImage) {
-        super();
-        this.setSelectedItems = setSelectedItems;
-        this.clearSelectedItems = clearSelectedItems;
-        this.onUpdateImage = onUpdateImage;
-        this.boundingBoxTool = new BoundingBoxTool(
-            Modes.OVAL,
-            setSelectedItems,
-            clearSelectedItems,
-            setCursor,
-            onUpdateImage
-        );
-        const nudgeTool = new NudgeTool(this.boundingBoxTool, onUpdateImage);
+        super(setSelectedItems, clearSelectedItems, setCursor, onUpdateImage, Modes.OVAL);
 
-        // We have to set these functions instead of just declaring them because
-        // paper.js tools hook up the listeners in the setter functions.
-        this.onMouseDown = this.handleMouseDown;
-        this.onMouseDrag = this.handleMouseDrag;
-        this.onMouseMove = this.handleMouseMove;
-        this.onMouseUp = this.handleMouseUp;
-        this.onKeyUp = nudgeTool.onKeyUp;
-        this.onKeyDown = nudgeTool.onKeyDown;
-
-        this.oval = null;
-        this.colorState = null;
-        this.isBoundingBoxMode = null;
-        this.active = false;
-    }
-    getHitOptions () {
-        return {
-            segments: true,
-            stroke: true,
-            curves: true,
-            fill: true,
-            guide: false,
-            match: hitResult =>
-                (hitResult.item.data && (hitResult.item.data.isScaleHandle || hitResult.item.data.isRotHandle)) ||
-                hitResult.item.selected, // Allow hits on bounding box and selected only
-            tolerance: OvalTool.TOLERANCE / paper.view.zoom
-        };
-    }
-    /**
-     * Should be called if the selection changes to update the bounds of the bounding box.
-     * @param {Array<paper.Item>} selectedItems Array of selected items.
-     */
-    onSelectionChanged (selectedItems) {
-        this.boundingBoxTool.onSelectionChanged(selectedItems);
-    }
-    setColorState (colorState) {
-        this.colorState = colorState;
-    }
-    handleMouseDown (event) {
-        if (event.event.button > 0) return; // only first mouse button
-        this.active = true;
-
-        if (this.boundingBoxTool.onMouseDown(
-            event, false /* clone */, false /* multiselect */, false /* doubleClicked */, this.getHitOptions())) {
-            this.isBoundingBoxMode = true;
-        } else {
-            this.isBoundingBoxMode = false;
-            clearSelection(this.clearSelectedItems);
-            this.oval = new paper.Shape.Ellipse({
-                point: event.downPoint,
-                size: 0
-            });
-            styleShape(this.oval, this.colorState);
-        }
-    }
-    handleMouseDrag (event) {
-        if (event.event.button > 0 || !this.active) return; // only first mouse button
-
-        if (this.isBoundingBoxMode) {
-            this.boundingBoxTool.onMouseDrag(event);
-            return;
-        }
-
-        const downPoint = new paper.Point(event.downPoint.x, event.downPoint.y);
-        const point = new paper.Point(event.point.x, event.point.y);
-        const squareDimensions = getSquareDimensions(event.downPoint, event.point);
-        if (event.modifiers.shift) {
-            this.oval.size = squareDimensions.size.abs();
-        } else {
-            this.oval.size = downPoint.subtract(point);
-        }
-
-        if (event.modifiers.alt) {
-            this.oval.position = downPoint;
-        } else if (event.modifiers.shift) {
-            this.oval.position = squareDimensions.position;
-        } else {
-            this.oval.position = downPoint.subtract(this.oval.size.multiply(0.5));
-        }
-    }
-    handleMouseMove (event) {
-        this.boundingBoxTool.onMouseMove(event, this.getHitOptions());
-    }
-    handleMouseUp (event) {
-        if (event.event.button > 0 || !this.active) return; // only first mouse button
-
-        if (this.isBoundingBoxMode) {
-            this.boundingBoxTool.onMouseUp(event);
-            this.isBoundingBoxMode = null;
-            return;
-        }
-
-        if (this.oval) {
-            if (Math.abs(this.oval.size.width * this.oval.size.height) < OvalTool.TOLERANCE / paper.view.zoom) {
-                // Tiny oval created unintentionally?
-                this.oval.remove();
-                this.oval = null;
-            } else {
-                const ovalPath = this.oval.toPath(true /* insert */);
-                this.oval.remove();
-                this.oval = null;
-
-                ovalPath.selected = true;
-                this.setSelectedItems();
-                this.onUpdateImage();
-            }
-        }
-        this.active = false;
-    }
-    deactivateTool () {
-        this.boundingBoxTool.deactivateTool();
+        this.shapeConstructor = paper.Shape.Ellipse;
     }
 }
 

--- a/src/helper/tools/rect-tool.js
+++ b/src/helper/tools/rect-tool.js
@@ -1,18 +1,11 @@
 import paper from '@scratch/paper';
 import Modes from '../../lib/modes';
-import {styleShape} from '../style-path';
-import {clearSelection} from '../selection';
-import {getSquareDimensions} from '../math';
-import BoundingBoxTool from '../selection-tools/bounding-box-tool';
-import NudgeTool from '../selection-tools/nudge-tool';
+import ShapeTool from './shape-tool';
 
 /**
  * Tool for drawing rectangles.
  */
-class RectTool extends paper.Tool {
-    static get TOLERANCE () {
-        return 2;
-    }
+class RectTool extends ShapeTool {
     /**
      * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
      * @param {function} clearSelectedItems Callback to clear the set of selected items in the Redux state
@@ -20,126 +13,9 @@ class RectTool extends paper.Tool {
      * @param {!function} onUpdateImage A callback to call when the image visibly changes
      */
     constructor (setSelectedItems, clearSelectedItems, setCursor, onUpdateImage) {
-        super();
-        this.setSelectedItems = setSelectedItems;
-        this.clearSelectedItems = clearSelectedItems;
-        this.onUpdateImage = onUpdateImage;
-        this.boundingBoxTool = new BoundingBoxTool(
-            Modes.RECT,
-            setSelectedItems,
-            clearSelectedItems,
-            setCursor,
-            onUpdateImage
-        );
-        const nudgeTool = new NudgeTool(this.boundingBoxTool, onUpdateImage);
+        super(setSelectedItems, clearSelectedItems, setCursor, onUpdateImage, Modes.RECT);
 
-        // We have to set these functions instead of just declaring them because
-        // paper.js tools hook up the listeners in the setter functions.
-        this.onMouseDown = this.handleMouseDown;
-        this.onMouseMove = this.handleMouseMove;
-        this.onMouseDrag = this.handleMouseDrag;
-        this.onMouseUp = this.handleMouseUp;
-        this.onKeyUp = nudgeTool.onKeyUp;
-        this.onKeyDown = nudgeTool.onKeyDown;
-
-        this.rect = null;
-        this.colorState = null;
-        this.isBoundingBoxMode = null;
-        this.active = false;
-    }
-    getHitOptions () {
-        return {
-            segments: true,
-            stroke: true,
-            curves: true,
-            fill: true,
-            guide: false,
-            match: hitResult =>
-                (hitResult.item.data && (hitResult.item.data.isScaleHandle || hitResult.item.data.isRotHandle)) ||
-                hitResult.item.selected, // Allow hits on bounding box and selected only
-            tolerance: RectTool.TOLERANCE / paper.view.zoom
-        };
-    }
-    /**
-     * Should be called if the selection changes to update the bounds of the bounding box.
-     * @param {Array<paper.Item>} selectedItems Array of selected items.
-     */
-    onSelectionChanged (selectedItems) {
-        this.boundingBoxTool.onSelectionChanged(selectedItems);
-    }
-    setColorState (colorState) {
-        this.colorState = colorState;
-    }
-    handleMouseDown (event) {
-        if (event.event.button > 0) return; // only first mouse button
-        this.active = true;
-
-        if (this.boundingBoxTool.onMouseDown(
-            event, false /* clone */, false /* multiselect */, false /* doubleClicked */, this.getHitOptions())) {
-            this.isBoundingBoxMode = true;
-        } else {
-            this.isBoundingBoxMode = false;
-            clearSelection(this.clearSelectedItems);
-        }
-    }
-    handleMouseDrag (event) {
-        if (event.event.button > 0 || !this.active) return; // only first mouse button
-
-        if (this.isBoundingBoxMode) {
-            this.boundingBoxTool.onMouseDrag(event);
-            return;
-        }
-
-        if (this.rect) {
-            this.rect.remove();
-        }
-
-        const rect = new paper.Rectangle(event.downPoint, event.point);
-        const squareDimensions = getSquareDimensions(event.downPoint, event.point);
-        if (event.modifiers.shift) {
-            rect.size = squareDimensions.size.abs();
-        }
-
-        this.rect = new paper.Path.Rectangle(rect);
-        if (event.modifiers.alt) {
-            this.rect.position = event.downPoint;
-        } else if (event.modifiers.shift) {
-            this.rect.position = squareDimensions.position;
-        } else {
-            const dimensions = event.point.subtract(event.downPoint);
-            this.rect.position = event.downPoint.add(dimensions.multiply(0.5));
-        }
-
-        styleShape(this.rect, this.colorState);
-    }
-    handleMouseUp (event) {
-        if (event.event.button > 0 || !this.active) return; // only first mouse button
-
-        if (this.isBoundingBoxMode) {
-            this.boundingBoxTool.onMouseUp(event);
-            this.isBoundingBoxMode = null;
-            return;
-        }
-
-        if (this.rect) {
-            if (this.rect.area < RectTool.TOLERANCE / paper.view.zoom) {
-                // Tiny rectangle created unintentionally?
-                this.rect.remove();
-                this.rect = null;
-            } else {
-                this.rect.selected = true;
-                this.setSelectedItems();
-                this.onUpdateImage();
-                this.rect = null;
-            }
-        }
-        this.active = false;
-    }
-    handleMouseMove (event) {
-        this.boundingBoxTool.onMouseMove(event, this.getHitOptions());
-    }
-    deactivateTool () {
-        this.boundingBoxTool.deactivateTool();
+        this.shapeConstructor = paper.Shape.Rectangle;
     }
 }
 

--- a/src/helper/tools/shape-tool.js
+++ b/src/helper/tools/shape-tool.js
@@ -1,0 +1,148 @@
+import paper from '@scratch/paper';
+import {styleShape} from '../style-path';
+import {clearSelection} from '../selection';
+import {getSquareDimensions} from '../math';
+import BoundingBoxTool from '../selection-tools/bounding-box-tool';
+import NudgeTool from '../selection-tools/nudge-tool';
+
+/**
+ * Tool for drawing shapes (e.g. rectangles and ovals).
+ */
+class ShapeTool extends paper.Tool {
+    static get TOLERANCE () {
+        return 2;
+    }
+    /**
+     * @param {function} setSelectedItems Callback to set the set of selected items in the Redux state
+     * @param {function} clearSelectedItems Callback to clear the set of selected items in the Redux state
+     * @param {function} setCursor Callback to set the visible mouse cursor
+     * @param {!function} onUpdateImage A callback to call when the image visibly changes
+     * @param {VectorModes} mode This tool's "mode"
+     */
+    constructor (setSelectedItems, clearSelectedItems, setCursor, onUpdateImage, mode) {
+        super();
+        this.setSelectedItems = setSelectedItems;
+        this.clearSelectedItems = clearSelectedItems;
+        this.onUpdateImage = onUpdateImage;
+        this.boundingBoxTool = new BoundingBoxTool(
+            mode,
+            setSelectedItems,
+            clearSelectedItems,
+            setCursor,
+            onUpdateImage
+        );
+        const nudgeTool = new NudgeTool(this.boundingBoxTool, onUpdateImage);
+
+        // We have to set these functions instead of just declaring them because
+        // paper.js tools hook up the listeners in the setter functions.
+        this.onMouseDown = this.handleMouseDown;
+        this.onMouseMove = this.handleMouseMove;
+        this.onMouseDrag = this.handleMouseDrag;
+        this.onMouseUp = this.handleMouseUp;
+        this.onKeyUp = nudgeTool.onKeyUp;
+        this.onKeyDown = nudgeTool.onKeyDown;
+
+        this.shape = null;
+        this.colorState = null;
+        this.isBoundingBoxMode = null;
+        this.active = false;
+    }
+    getHitOptions () {
+        return {
+            segments: true,
+            stroke: true,
+            curves: true,
+            fill: true,
+            guide: false,
+            match: hitResult =>
+                (hitResult.item.data && (hitResult.item.data.isScaleHandle || hitResult.item.data.isRotHandle)) ||
+                hitResult.item.selected, // Allow hits on bounding box and selected only
+            tolerance: ShapeTool.TOLERANCE / paper.view.zoom
+        };
+    }
+    /**
+     * Should be called if the selection changes to update the bounds of the bounding box.
+     * @param {Array<paper.Item>} selectedItems Array of selected items.
+     */
+    onSelectionChanged (selectedItems) {
+        this.boundingBoxTool.onSelectionChanged(selectedItems);
+    }
+    setColorState (colorState) {
+        this.colorState = colorState;
+    }
+    handleMouseDown (event) {
+        if (event.event.button > 0) return; // only first mouse button
+        this.active = true;
+
+        if (this.boundingBoxTool.onMouseDown(
+            event, false /* clone */, false /* multiselect */, false /* doubleClicked */, this.getHitOptions())) {
+            this.isBoundingBoxMode = true;
+        } else {
+            this.isBoundingBoxMode = false;
+            clearSelection(this.clearSelectedItems);
+            this.shape = new this.shapeConstructor({
+                point: event.downPoint,
+                size: 0
+            });
+            styleShape(this.shape, this.colorState);
+        }
+    }
+    handleMouseDrag (event) {
+        if (event.event.button > 0 || !this.active) return; // only first mouse button
+
+        if (this.isBoundingBoxMode) {
+            this.boundingBoxTool.onMouseDrag(event);
+            return;
+        }
+
+        const downPoint = new paper.Point(event.downPoint.x, event.downPoint.y);
+        const point = new paper.Point(event.point.x, event.point.y);
+        const squareDimensions = getSquareDimensions(event.downPoint, event.point);
+        const realSize = downPoint.subtract(point);
+        if (event.modifiers.shift) {
+            this.shape.size = squareDimensions.size.abs();
+        } else {
+            // Setting a negative size messes up the shape's radius, so keep it positive.
+            this.shape.size = realSize.abs();
+        }
+
+        if (event.modifiers.alt) {
+            this.shape.position = downPoint;
+        } else if (event.modifiers.shift) {
+            this.shape.position = squareDimensions.position;
+        } else {
+            this.shape.position = downPoint.subtract(realSize.multiply(0.5));
+        }
+    }
+    handleMouseUp (event) {
+        if (event.event.button > 0 || !this.active) return; // only first mouse button
+
+        if (this.isBoundingBoxMode) {
+            this.boundingBoxTool.onMouseUp(event);
+            this.isBoundingBoxMode = null;
+            return;
+        }
+
+        if (this.shape) {
+            if (this.shape.area < ShapeTool.TOLERANCE / paper.view.zoom) {
+                // Tiny shape created unintentionally?
+                this.shape.remove();
+                this.shape = null;
+            } else {
+                this.shape.selected = true;
+                this.setSelectedItems();
+                this.onUpdateImage();
+                this.shape = null;
+            }
+        }
+        this.active = false;
+    }
+    handleMouseMove (event) {
+        this.boundingBoxTool.onMouseMove(event, this.getHitOptions());
+    }
+    deactivateTool () {
+        this.boundingBoxTool.deactivateTool();
+    }
+}
+
+export default ShapeTool;


### PR DESCRIPTION
This PR includes #919

### Proposed Changes

This PR moves code shared between `RectTool` and `OvalTool` into a `ShapeTool` base class that `RectTool` and `OvalTool` now inherit from. It does this for both bitmap and vector tools (there's both a bitmap `ShapeTool` and a vector `ShapeTool`).

The changed code lies in `handleMouseDrag`, which I modified to always set a positive value for the shape's size. This is to prevent rectangle shapes' `radius` attribute from getting messed up due to a paper.js bug.

### Reason for Changes

These changes greatly reduce the amount of duplicated code, making it easier to modify tool behavior in the future.