### PR TITLE
Skip processing of child paths in mergeEraser

### DIFF
--- a/src/helper/blob-tools/blob.js
+++ b/src/helper/blob-tools/blob.js
@@ -5,6 +5,7 @@ import SegmentBrushHelper from './segment-brush-helper';
 import {MIXED, styleCursorPreview} from '../../helper/style-path';
 import {clearSelection, getItems} from '../../helper/selection';
 import {getGuideLayer} from '../../helper/layer';
+import {isCompoundPathChild} from '../compound-path';
 
 /**
  * Shared code for the brush and eraser mode. Adds functions on the paper tool object
@@ -263,8 +264,12 @@ class Blobbiness {
                 class: paper.PathItem
             });
         }
-        
+
         for (let i = items.length - 1; i >= 0; i--) {
+            // If a path is part of a compound path, that parent path will later be processed.
+            // Skip processing the child path so as not to double-process it.
+            if (isCompoundPathChild(items[i])) continue;
+
             // TODO handle compound paths
             if (items[i] instanceof paper.Path && (!items[i].fillColor || items[i].fillColor._alpha === 0)) {
                 // Gather path segments


### PR DESCRIPTION
### Resolves

Resolves #621
Resolves #120
Resolves #119

### Proposed Changes

This PR modifies the shape Boolean processing loop in `Blobbiness.mergeEraser` to skip processing paths that are children of compound paths.

### Reason for Changes

Both child paths and their parents are included in the list of items that `mergeEraser` will attempt to merge with. If child paths are not specifically excluded, `mergeEraser` will attempt to operate on them twice: once with their parent path, and one with them on their own.

Fixing this greatly improves the reliability of eraser operations:

Before | After
-|-
![mergeeraser-before](https://user-images.githubusercontent.com/25993062/68503737-92563e00-0231-11ea-8d29-836ded89a883.gif) | ![mergeeraser-after](https://user-images.githubusercontent.com/25993062/68503743-94b89800-0231-11ea-98ce-1cd362fb1403.gif)
![mergeeraser-before-2](https://user-images.githubusercontent.com/25993062/68517828-238bdb80-0257-11ea-9159-e161e3eef681.gif) | ![mergeeraser-after-2](https://user-images.githubusercontent.com/25993062/68517844-356d7e80-0257-11ea-9a00-2a5ca26b07ef.gif)

