### PR TITLE
Skip processing of child paths in swapColorsInSelection

### DIFF
--- a/src/helper/style-path.js
+++ b/src/helper/style-path.js
@@ -6,6 +6,7 @@ import {getItems} from './selection';
 import GradientTypes from '../lib/gradient-types';
 import parseColor from 'parse-color';
 import {DEFAULT_COLOR} from '../reducers/fill-color';
+import {isCompoundPathChild} from '../helper/compound-path';
 
 const MIXED = 'scratch-paint/style-path/mixed';
 
@@ -159,10 +160,11 @@ const applyFillColorToSelection = function (colorString, colorIndex, isSolidGrad
 const swapColorsInSelection = function (bitmapMode, textEditTargetId) {
     const items = _getColorStateListeners(textEditTargetId);
     let changed = false;
-    for (let item of items) {
-        if (item.parent instanceof paper.CompoundPath) {
-            item = item.parent;
-        }
+    for (const item of items) {
+        // If an item is a child path, do not swap colors.
+        // At some point, we'll iterate over its parent path, and we don't want to swap colors twice--
+        // that would leave us right where we started.
+        if (isCompoundPathChild(item)) continue;
 
         if (bitmapMode) {
             // @todo


### PR DESCRIPTION
### Resolves

Resolves #567

### Proposed Changes

This PR changes the loop over all selected items in `swapColorsInSelection` to skip over child paths.

### Reason for Changes

The list of selected items contains both compound paths and their children.
Previously, the code would check if the path being iterated over was a child path, but if so it would instead swap the colors on the parent path. This is incorrect, as both the parent path and all of its child paths appear in the list of items and will eventually be iterated over.

This would fail on shapes with even numbers of holes because of the number of items being iterated over:

* For a single shape, there's one `Path` item, so swapping works
* For a shape with one hole, there's one `CompoundPath` item with two child `Path`s (one for the shape, one for the hole), so there are 3 total items and 3 total swaps and it works
* For a shape with two holes, there's one `CompoundPath` with three child `Path`s, so there are 4 swaps and it doesn't work