### PR TITLE
Fix stacking buttons

### DIFF
--- a/src/components/button-group/button-group.css
+++ b/src/components/button-group/button-group.css
@@ -1,5 +1,6 @@
 @import "../../css/units";
 
 .button-group {
+    display: flex;
     padding: 0 $grid-unit;
 }

--- a/src/components/dropdown/dropdown.css
+++ b/src/components/dropdown/dropdown.css
@@ -9,6 +9,8 @@ $arrow-border-width: 14px;
     min-width: 3.5rem;
     color: $motion-primary;
     padding: .5rem;
+    display: flex;
+    align-items: center;
 }
 
 .mod-open {

--- a/src/components/input-group/input-group.css
+++ b/src/components/input-group/input-group.css
@@ -8,6 +8,10 @@
     margin-right: calc(2 * $grid-unit);
 }
 
+.input-group {
+    display:flex;
+}
+
 .disabled {
     opacity: 0.3;
     /* Prevent any user actions */

--- a/src/components/paint-editor/paint-editor.css
+++ b/src/components/paint-editor/paint-editor.css
@@ -126,7 +126,7 @@ $border-radius: 0.25rem;
 
 .mode-selector {
     display: flex;
-    max-width: 7.8rem;
+    max-width: 6rem;
     flex-direction: row;
     flex-wrap: wrap;
     align-items: flex-start;

--- a/src/components/paint-editor/paint-editor.css
+++ b/src/components/paint-editor/paint-editor.css
@@ -126,7 +126,7 @@ $border-radius: 0.25rem;
 
 .mode-selector {
     display: flex;
-    max-width: 6rem;
+    max-width: 7.8rem;
     flex-direction: row;
     flex-wrap: wrap;
     align-items: flex-start;

--- a/src/css/units.css
+++ b/src/css/units.css
@@ -23,4 +23,4 @@ $form-radius: calc($space / 2);
 
 /* layout contants from `layout-constants.js`, minus 1px */
 $full-size: 1095px;
-$full-size-paint: 1249px;
+$full-size-paint: 1256px;


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/248

The max width change fixes an issue where the paint editor can be in expanded view mode, but the tools are still briefly in 1 column. Ideas for a better way to do it would be appreciated!
<img width="596" alt="Screen Shot 2019-11-13 at 16 35 54" src="https://user-images.githubusercontent.com/2855464/68813519-0cc4fa80-0644-11ea-90bc-34f9e1dfbea3.png">
