### PR TITLE
Use Paper.Color instead of CSS color strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "lodash.bindall": "4.4.0",
     "lodash.omit": "4.5.0",
     "minilog": "3.1.0",
-    "parse-color": "1.0.0",
     "prop-types": "^15.5.10",
     "scratch-svg-renderer": "0.2.0-prerelease.20200610220938"
   },

--- a/src/components/color-button/color-button.jsx
+++ b/src/components/color-button/color-button.jsx
@@ -9,11 +9,15 @@ import mixedFillIcon from './mixed-fill.svg';
 import styles from './color-button.css';
 import GradientTypes from '../../lib/gradient-types';
 import log from '../../log/log';
+import ColorProptype from '../../lib/color-proptype';
 
 const colorToBackground = (color, color2, gradientType) => {
     if (color === MIXED || (gradientType !== GradientTypes.SOLID && color2 === MIXED)) return 'white';
-    if (color === null) color = 'white';
-    if (color2 === null) color2 = 'white';
+    if (color === MIXED || color2 === MIXED) return 'white';
+
+    color = (color === null) ? 'white' : color.toCSS();
+    color2 = (color2 === null) ? 'white' : color2.toCSS();
+
     switch (gradientType) {
     case GradientTypes.SOLID: return color;
     case GradientTypes.HORIZONTAL: return `linear-gradient(to right, ${color}, ${color2})`;
@@ -55,8 +59,8 @@ const ColorButtonComponent = props => (
 );
 
 ColorButtonComponent.propTypes = {
-    color: PropTypes.string,
-    color2: PropTypes.string,
+    color: ColorProptype,
+    color2: ColorProptype,
     gradientType: PropTypes.oneOf(Object.keys(GradientTypes)).isRequired,
     onClick: PropTypes.func.isRequired,
     outline: PropTypes.bool.isRequired

--- a/src/components/color-indicator.jsx
+++ b/src/components/color-indicator.jsx
@@ -8,6 +8,7 @@ import InputGroup from './input-group/input-group.jsx';
 import Label from './forms/label.jsx';
 
 import GradientTypes from '../lib/gradient-types';
+import ColorProptype from '../lib/color-proptype';
 
 const ColorIndicatorComponent = props => (
     <InputGroup
@@ -46,8 +47,8 @@ const ColorIndicatorComponent = props => (
 ColorIndicatorComponent.propTypes = {
     className: PropTypes.string,
     disabled: PropTypes.bool.isRequired,
-    color: PropTypes.string,
-    color2: PropTypes.string,
+    color: ColorProptype,
+    color2: ColorProptype,
     colorModalVisible: PropTypes.bool.isRequired,
     gradientType: PropTypes.oneOf(Object.keys(GradientTypes)).isRequired,
     label: PropTypes.string.isRequired,

--- a/src/containers/bit-brush-mode.jsx
+++ b/src/containers/bit-brush-mode.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
+import ColorProptype from '../lib/color-proptype';
 import bindAll from 'lodash.bindall';
 import Modes from '../lib/modes';
 import {MIXED} from '../helper/style-path';
@@ -84,7 +85,7 @@ BitBrushMode.propTypes = {
     bitBrushSize: PropTypes.number.isRequired,
     clearGradient: PropTypes.func.isRequired,
     clearSelectedItems: PropTypes.func.isRequired,
-    color: PropTypes.string,
+    color: ColorProptype,
     handleMouseDown: PropTypes.func.isRequired,
     isBitBrushModeActive: PropTypes.bool.isRequired,
     onChangeFillColor: PropTypes.func.isRequired,

--- a/src/containers/bit-fill-mode.jsx
+++ b/src/containers/bit-fill-mode.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
+import ColorProptype from '../lib/color-proptype';
 import bindAll from 'lodash.bindall';
 import Modes from '../lib/modes';
 import GradientTypes from '../lib/gradient-types';
@@ -102,8 +103,8 @@ class BitFillMode extends React.Component {
 BitFillMode.propTypes = {
     changeGradientType: PropTypes.func.isRequired,
     clearSelectedItems: PropTypes.func.isRequired,
-    color: PropTypes.string,
-    color2: PropTypes.string,
+    color: ColorProptype,
+    color2: ColorProptype,
     styleGradientType: PropTypes.oneOf(Object.keys(GradientTypes)).isRequired,
     fillModeGradientType: PropTypes.oneOf(Object.keys(GradientTypes)),
     handleMouseDown: PropTypes.func.isRequired,

--- a/src/containers/bit-line-mode.jsx
+++ b/src/containers/bit-line-mode.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
+import ColorProptype from '../lib/color-proptype';
 import bindAll from 'lodash.bindall';
 import Modes from '../lib/modes';
 import {MIXED} from '../helper/style-path';
@@ -84,7 +85,7 @@ BitLineMode.propTypes = {
     bitBrushSize: PropTypes.number.isRequired,
     clearGradient: PropTypes.func.isRequired,
     clearSelectedItems: PropTypes.func.isRequired,
-    color: PropTypes.string,
+    color: ColorProptype,
     handleMouseDown: PropTypes.func.isRequired,
     isBitLineModeActive: PropTypes.bool.isRequired,
     onChangeFillColor: PropTypes.func.isRequired,

--- a/src/containers/color-indicator.jsx
+++ b/src/containers/color-indicator.jsx
@@ -1,21 +1,20 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import bindAll from 'lodash.bindall';
-import parseColor from 'parse-color';
 import {injectIntl, intlShape} from 'react-intl';
 
 import {getSelectedLeafItems} from '../helper/selection';
 import Formats from '../lib/format';
 import {isBitmap} from '../lib/format';
 import GradientTypes from '../lib/gradient-types';
+import ColorProptype from '../lib/color-proptype';
 
 import ColorIndicatorComponent from '../components/color-indicator.jsx';
 import {applyColorToSelection,
     applyGradientTypeToSelection,
     applyStrokeWidthToSelection,
     generateSecondaryColor,
-    swapColorsInSelection,
-    MIXED} from '../helper/style-path';
+    swapColorsInSelection} from '../helper/style-path';
 
 const makeColorIndicator = (label, isStroke) => {
     class ColorIndicator extends React.Component {
@@ -123,12 +122,8 @@ const makeColorIndicator = (label, isStroke) => {
                 this.props.setSelectedItems(this.props.format);
                 this._hasChanged = this._hasChanged || isDifferent;
             } else {
-                let color1 = this.props.color;
-                let color2 = this.props.color2;
-                color1 = color1 === null || color1 === MIXED ? color1 : parseColor(color1).hex;
-                color2 = color2 === null || color2 === MIXED ? color2 : parseColor(color2).hex;
-                this.props.onChangeColor(color1, 1);
-                this.props.onChangeColor(color2, 0);
+                this.props.onChangeColor(this.props.color, 1);
+                this.props.onChangeColor(this.props.color2, 0);
             }
         }
         render () {
@@ -149,8 +144,8 @@ const makeColorIndicator = (label, isStroke) => {
     ColorIndicator.propTypes = {
         colorIndex: PropTypes.number.isRequired,
         disabled: PropTypes.bool.isRequired,
-        color: PropTypes.string,
-        color2: PropTypes.string,
+        color: ColorProptype,
+        color2: ColorProptype,
         colorModalVisible: PropTypes.bool.isRequired,
         fillBitmapShapes: PropTypes.bool.isRequired,
         format: PropTypes.oneOf(Object.keys(Formats)),

--- a/src/containers/fill-mode.jsx
+++ b/src/containers/fill-mode.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
+import ColorProptype from '../lib/color-proptype';
 import bindAll from 'lodash.bindall';
 import Modes from '../lib/modes';
 import GradientTypes from '../lib/gradient-types';
@@ -112,8 +113,8 @@ FillMode.propTypes = {
     changeGradientType: PropTypes.func.isRequired,
     clearHoveredItem: PropTypes.func.isRequired,
     clearSelectedItems: PropTypes.func.isRequired,
-    fillColor: PropTypes.string,
-    fillColor2: PropTypes.string,
+    fillColor: ColorProptype,
+    fillColor2: ColorProptype,
     fillStyleGradientType: PropTypes.oneOf(Object.keys(GradientTypes)).isRequired,
     fillModeGradientType: PropTypes.oneOf(Object.keys(GradientTypes)),
     handleMouseDown: PropTypes.func.isRequired,

--- a/src/containers/line-mode.jsx
+++ b/src/containers/line-mode.jsx
@@ -23,7 +23,7 @@ class LineMode extends React.Component {
         return 6;
     }
     static get DEFAULT_COLOR () {
-        return '#000000';
+        return new paper.Color({hue: 0, saturation: 0, brightness: 0});
     }
     constructor (props) {
         super(props);

--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -254,14 +254,14 @@ class PaintEditor extends React.Component {
     }
     onMouseUp () {
         if (this.props.isEyeDropping) {
-            const colorString = this.eyeDropper.colorString;
+            const color = this.eyeDropper.color;
             const callback = this.props.changeColorToEyeDropper;
 
             this.eyeDropper.remove();
             if (!this.eyeDropper.hideLoupe) {
                 // If not hide loupe, that means the click is inside the canvas,
                 // so apply the new color
-                callback(colorString);
+                callback(color);
             }
             if (this.props.previousTool) this.props.previousTool.activate();
             this.props.onDeactivateEyeDropper();

--- a/src/containers/stroke-width-indicator.jsx
+++ b/src/containers/stroke-width-indicator.jsx
@@ -2,8 +2,7 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 import bindAll from 'lodash.bindall';
-import parseColor from 'parse-color';
-import {changeStrokeColor, changeStrokeColor2, changeStrokeGradientType} from '../reducers/stroke-style';
+import {changeStrokeColor, changeStrokeColor2, changeStrokeGradientType, DEFAULT_COLOR} from '../reducers/stroke-style';
 import {changeStrokeWidth} from '../reducers/stroke-width';
 import StrokeWidthIndicatorComponent from '../components/stroke-width-indicator.jsx';
 import {getSelectedLeafItems} from '../helper/selection';
@@ -13,6 +12,7 @@ import GradientTypes from '../lib/gradient-types';
 import Modes from '../lib/modes';
 import Formats from '../lib/format';
 import {isBitmap} from '../lib/format';
+import paper from '@scratch/paper';
 
 class StrokeWidthIndicator extends React.Component {
     constructor (props) {
@@ -34,7 +34,7 @@ class StrokeWidthIndicator extends React.Component {
 
             if (wasNull) {
                 changed = applyColorToSelection(
-                    '#000',
+                    DEFAULT_COLOR,
                     0, // colorIndex,
                     true, // isSolidGradient
                     true, // applyToStroke
@@ -42,12 +42,12 @@ class StrokeWidthIndicator extends React.Component {
                     changed;
                 // If there's no previous stroke color, default to solid black
                 this.props.onChangeStrokeGradientType(GradientTypes.SOLID);
-                this.props.onChangeStrokeColor('#000');
+                this.props.onChangeStrokeColor(DEFAULT_COLOR);
             } else if (currentColorState.strokeColor !== MIXED) {
                 // Set color state from the selected item's stroke color
                 this.props.onChangeStrokeGradientType(currentColorState.strokeGradientType);
-                this.props.onChangeStrokeColor(parseColor(currentColorState.strokeColor).hex);
-                this.props.onChangeStrokeColor2(parseColor(currentColorState.strokeColor2).hex);
+                this.props.onChangeStrokeColor(currentColorState.strokeColor);
+                this.props.onChangeStrokeColor2(currentColorState.strokeColor2);
             }
         }
         this.props.onChangeStrokeWidth(newWidth);

--- a/src/helper/style-path.js
+++ b/src/helper/style-path.js
@@ -13,15 +13,26 @@ const MIXED = 'scratch-paint/style-path/mixed';
 // Check if two colors, possibly null, are (approximately) equal.
 const _colorsEqual = (color1, color2) => {
     if (color1 === color2) return true;
-    // Handle nulls. We know they can't both be null, because we'd have already returned true if they were.
     if (!color1 || !color2) return false;
 
-    // If either one of the colors doesn't have a `toCSS` method, it isn't a paper.js Color object,
-    // and we've already handled the case where neither is a Color object and they're both equal.
-    if (!(color1.toCSS && color2.toCSS)) return false;
+    if (!(color1 instanceof paper.Color && color2 instanceof paper.Color)) {
+        log.warn('_colorsEqual passed non-Colors');
+        return false;
+    }
 
-    // Convert to CSS in case e.g. one color is RGB and the other is HSB
-    return color1.toCSS() === color2.toCSS();
+    const hsb1 = color1.type === 'hsb' ? color1 : color1.convert('hsb');
+    const hsb2 = color2.type === 'hsb' ? color2 : color2.convert('hsb');
+
+    // Colors that are similar enough, as determined by this threshold, will be considered equal.
+    // Copied from paper.js' Numerical.js. This is a good number. I like this number.
+    const EPSILON = 1e-12;
+
+    return (
+        Math.abs(hsb1.hue - hsb2.hue) < EPSILON &&
+        Math.abs(hsb1.saturation - hsb2.saturation) < EPSILON &&
+        Math.abs(hsb1.brightness - hsb2.brightness) < EPSILON &&
+        Math.abs(hsb1.alpha - hsb2.alpha) < EPSILON
+    );
 };
 
 // Selected items and currently active text edit items respond to color changes.

--- a/src/helper/tools/eye-dropper.js
+++ b/src/helper/tools/eye-dropper.js
@@ -43,7 +43,7 @@ class EyeDropperTool extends paper.Tool {
         this.width = width * this.zoom * this.pixelRatio;
         this.height = height * this.zoom * this.pixelRatio;
         this.rect = canvas.getBoundingClientRect();
-        this.colorString = '';
+        this.color = null;
         this.pickX = -1;
         this.pickY = -1;
         this.hideLoupe = true;
@@ -71,20 +71,20 @@ class EyeDropperTool extends paper.Tool {
             if (!colorInfo) return;
             if (colorInfo.color[3] === 0) {
                 // Alpha 0
-                this.colorString = null;
+                this.color = null;
                 return;
             }
-            const r = colorInfo.color[0];
-            const g = colorInfo.color[1];
-            const b = colorInfo.color[2];
 
-            // from https://github.com/LLK/scratch-gui/blob/77e54a80a31b6cd4684d4b2a70f1aeec671f229e/src/containers/stage.jsx#L218-L222
-            // formats the color info from the canvas into hex for parsing by the color picker
-            const componentToString = c => {
-                const hex = c.toString(16);
-                return hex.length === 1 ? `0${hex}` : hex;
-            };
-            this.colorString = `#${componentToString(r)}${componentToString(g)}${componentToString(b)}`;
+            const color = new paper.Color(
+                colorInfo.color[0] / 255,
+                colorInfo.color[1] / 255,
+                colorInfo.color[2] / 255
+            );
+
+            // Convert color's backing components to HSV a.k.a. HSB
+            color.type = 'hsb';
+
+            this.color = color;
         }
     }
     getColorInfo (x, y, hideLoupe) {

--- a/src/lib/color-proptype.js
+++ b/src/lib/color-proptype.js
@@ -1,0 +1,10 @@
+import paper from '@scratch/paper';
+import PropTypes from 'prop-types';
+import {MIXED} from '../helper/style-path';
+
+const colorProptype = PropTypes.oneOfType([
+    PropTypes.instanceOf(paper.Color),
+    PropTypes.oneOf([MIXED])
+]);
+
+export default colorProptype;

--- a/src/lib/color-style-proptype.js
+++ b/src/lib/color-style-proptype.js
@@ -1,9 +1,10 @@
 import {PropTypes} from 'prop-types';
 
 import GradientTypes from './gradient-types';
+import ColorProptype from './color-proptype';
 
 export default PropTypes.shape({
-    primary: PropTypes.string,
-    secondary: PropTypes.string,
+    primary: ColorProptype,
+    secondary: ColorProptype,
     gradientType: PropTypes.oneOf(Object.keys(GradientTypes)).isRequired
 });

--- a/src/lib/make-color-style-reducer.js
+++ b/src/lib/make-color-style-reducer.js
@@ -2,13 +2,11 @@ import log from '../log/log';
 import {CHANGE_SELECTED_ITEMS} from '../reducers/selected-items';
 import {getColorsFromSelection, MIXED} from '../helper/style-path';
 import GradientTypes from './gradient-types';
+import paper from '@scratch/paper';
 
-// Matches hex colors
-const hexRegex = /^#([0-9a-f]{3}){1,2}$/i;
-
-const isValidHexColor = color => {
-    if (!hexRegex.test(color) && color !== null && color !== MIXED) {
-        log.warn(`Invalid hex color code: ${color}`);
+const isValidColor = color => {
+    if (!(color instanceof paper.Color) && color !== null && color !== MIXED) {
+        log.warn(`Invalid color: ${color}`);
         return false;
     }
     return true;
@@ -44,10 +42,10 @@ const makeColorStyleReducer = ({
     }
     switch (action.type) {
     case changePrimaryColorAction:
-        if (!isValidHexColor(action.color)) return state;
+        if (!isValidColor(action.color)) return state;
         return {...state, primary: action.color};
     case changeSecondaryColorAction:
-        if (!isValidHexColor(action.color)) return state;
+        if (!isValidColor(action.color)) return state;
         return {...state, secondary: action.color};
     case CHANGE_SELECTED_ITEMS: {
         // Don't change state if no selection

--- a/src/reducers/fill-style.js
+++ b/src/reducers/fill-style.js
@@ -1,10 +1,11 @@
 import makeColorStyleReducer from '../lib/make-color-style-reducer';
+import paper from '@scratch/paper';
 
 const CHANGE_FILL_COLOR = 'scratch-paint/fill-style/CHANGE_FILL_COLOR';
 const CHANGE_FILL_COLOR_2 = 'scratch-paint/fill-style/CHANGE_FILL_COLOR_2';
 const CHANGE_FILL_GRADIENT_TYPE = 'scratch-paint/fill-style/CHANGE_FILL_GRADIENT_TYPE';
 const CLEAR_FILL_GRADIENT = 'scratch-paint/fill-style/CLEAR_FILL_GRADIENT';
-const DEFAULT_COLOR = '#9966FF';
+const DEFAULT_COLOR = new paper.Color({hue: 259, saturation: 0.6, brightness: 1});
 
 const reducer = makeColorStyleReducer({
     changePrimaryColorAction: CHANGE_FILL_COLOR,

--- a/src/reducers/stroke-style.js
+++ b/src/reducers/stroke-style.js
@@ -1,10 +1,11 @@
 import makeColorStyleReducer from '../lib/make-color-style-reducer';
+import paper from '@scratch/paper';
 
 const CHANGE_STROKE_COLOR = 'scratch-paint/stroke-style/CHANGE_STROKE_COLOR';
 const CHANGE_STROKE_COLOR_2 = 'scratch-paint/stroke-style/CHANGE_STROKE_COLOR_2';
 const CHANGE_STROKE_GRADIENT_TYPE = 'scratch-paint/stroke-style/CHANGE_STROKE_GRADIENT_TYPE';
 const CLEAR_STROKE_GRADIENT = 'scratch-paint/stroke-style/CLEAR_STROKE_GRADIENT';
-const DEFAULT_COLOR = '#000000';
+const DEFAULT_COLOR = new paper.Color({hue: 0, saturation: 0, brightness: 0});
 
 import {CHANGE_STROKE_WIDTH} from './stroke-width';
 


### PR DESCRIPTION
### Resolves

Resolves #610

### Proposed Changes

This PR changes the paint editor to consistently use `Paper.Color` objects to store color instead of CSS color strings.

### Reason for Changes

This prevents unexpected side effects of HSV > RGB > HSV conversion, such as certain color channels being zeroed out when brightness or saturation are set to 0.

It also allows increased flexibility with regards to future color improvements, notably a "transparency" slider (#834).

Because this touches a huge portion of the codebase, I'd like to look over it with fresh eyes once some more time has passed. I'm submitting this as a draft in case you want to look over it too.