### PR TITLE
Emit 1x1 blank bitmap data instead of full empty canvas

### DIFF
--- a/src/hocs/update-image-hoc.jsx
+++ b/src/hocs/update-image-hoc.jsx
@@ -90,13 +90,13 @@ const UpdateImageHOC = function (WrappedComponent) {
             }
             const rect = getHitBounds(plasteredRaster);
 
-            // Use 1x1 instead of 0x0 for getting imageData since paper.js automagically 
+            // Use 1x1 instead of 0x0 for getting imageData since paper.js automagically
             // returns the full artboard in the case of getImageData(0x0).
             // Bitmaps need a non-zero width/height in order to be saved as PNG.
             if (rect.width === 0 || rect.height === 0) {
                 rect.width = rect.height = 1;
             }
-            
+
             const imageData = plasteredRaster.getImageData(rect);
 
             this.props.onUpdateImage(

--- a/src/hocs/update-image-hoc.jsx
+++ b/src/hocs/update-image-hoc.jsx
@@ -89,14 +89,15 @@ const UpdateImageHOC = function (WrappedComponent) {
                 }
             }
             const rect = getHitBounds(plasteredRaster);
-            const imageData = plasteredRaster.getImageData(rect);
 
-            // If the bitmap has a zero width or height, save this information
-            // since zero isn't a valid value for on imageData objects' widths and heights.
+            // Use 1x1 instead of 0x0 for getting imageData since paper.js automagically 
+            // returns the full artboard in the case of getImageData(0x0).
+            // Bitmaps need a non-zero width/height in order to be saved as PNG.
             if (rect.width === 0 || rect.height === 0) {
-                imageData.sourceWidth = rect.width;
-                imageData.sourceHeight = rect.height;
+                rect.width = rect.height = 1;
             }
+            
+            const imageData = plasteredRaster.getImageData(rect);
 
             this.props.onUpdateImage(
                 false /* isVector */,


### PR DESCRIPTION
This fixes the issue where you cannot save blank bitmaps in scratch. We were trying to create PNG files which cannot have 0x0 size.

/cc @fsih 