### PR TITLE
Fix Safari crash in color picker

### DIFF
--- a/src/components/loupe/loupe.jsx
+++ b/src/components/loupe/loupe.jsx
@@ -41,7 +41,16 @@ class LoupeComponent extends React.Component {
         const imageData = tmpCtx.createImageData(
             loupeDiameter, loupeDiameter
         );
-        imageData.data.set(this.props.colorInfo.data);
+
+        // Since the color info comes from elsewhere there is no guarantee
+        // about the size. Make sure it matches to prevent data.set from throwing.
+        // See issue #966 for example of how that can happen.
+        if (this.props.colorInfo.data.length === imageData.data.length) {
+            imageData.data.set(this.props.colorInfo.data);
+        } else {
+            console.warn('Image data size mismatch drawing loupe'); // eslint-disable-line no-console
+        }
+
         tmpCtx.putImageData(imageData, 0, 0);
 
         // Scale the loupe canvas and draw the zoomed image

--- a/src/helper/tools/eye-dropper.js
+++ b/src/helper/tools/eye-dropper.js
@@ -99,8 +99,8 @@ class EyeDropperTool extends paper.Tool {
             y: y,
             color: colors.data,
             data: bufferContext.getImageData(
-                (artX * ZOOM_SCALE) - (LOUPE_RADIUS * ZOOM_SCALE),
-                (artY * ZOOM_SCALE) - (LOUPE_RADIUS * ZOOM_SCALE),
+                ZOOM_SCALE * (artX - LOUPE_RADIUS),
+                ZOOM_SCALE * (artY - LOUPE_RADIUS),
                 LOUPE_RADIUS * 2 * ZOOM_SCALE,
                 LOUPE_RADIUS * 2 * ZOOM_SCALE
             ).data,


### PR DESCRIPTION

### Resolves

_What Github issue does this resolve (please include link)?_

Fixes https://github.com/LLK/scratch-paint/issues/966

### Proposed Changes

_Describe what this Pull Request does_
Multiply after subtracting, not before, to prevent rounding error. That rounding error (described further in https://github.com/LLK/scratch-paint/issues/966) caused the resulting imageData to be the wrong size. That in turn caused the `data.set` call to throw an error. 

I also put in a size check where that data is eventually used, since it is completely disconnected from where the data comes from so has no guarantee about size. Also added a log.warn in order to make it clear if this problem comes up again in another way.
