### PR TITLE
Fix not resizing the crosshair when switching tabs and coming back to the costume tab

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -11,7 +11,7 @@ import {undoSnapshot, clearUndoState} from '../reducers/undo';
 import {isGroup, ungroupItems} from '../helper/group';
 import {clearRaster, getRaster, setupLayers} from '../helper/layer';
 import {clearSelectedItems} from '../reducers/selected-items';
-import {ART_BOARD_WIDTH, ART_BOARD_HEIGHT, resetZoom, zoomToFit} from '../helper/view';
+import {ART_BOARD_WIDTH, ART_BOARD_HEIGHT, resetZoom, resizeCrosshair, zoomToFit} from '../helper/view';
 import {ensureClockwise, scaleWithStrokes} from '../helper/math';
 import {clearHoveredItem} from '../reducers/hover';
 import {clearPasteOffset} from '../reducers/clipboard';
@@ -151,6 +151,7 @@ class PaperCanvas extends React.Component {
         if (this.shouldZoomToFit instanceof paper.Matrix) {
             paper.view.matrix = this.shouldZoomToFit;
             this.props.updateViewBounds(paper.view.matrix);
+            resizeCrosshair();
         } else if (this.shouldZoomToFit === true) {
             zoomToFit(isBitmapMode);
             this.props.updateViewBounds(paper.view.matrix);

--- a/src/helper/view.js
+++ b/src/helper/view.js
@@ -31,7 +31,7 @@ const clampViewBounds = () => {
     }
 };
 
-const _resizeCrosshair = () => {
+const resizeCrosshair = () => {
     if (getDragCrosshairLayer() && getDragCrosshairLayer().dragCrosshair) {
         getDragCrosshairLayer().dragCrosshair.scale(
             CROSSHAIR_SIZE / getDragCrosshairLayer().dragCrosshair.bounds.width / paper.view.zoom);
@@ -55,7 +55,7 @@ const zoomOnFixedPoint = (deltaZoom, fixedPoint) => {
     view.zoom = newZoom;
     view.translate(postZoomOffset.multiply(-1));
     clampViewBounds();
-    _resizeCrosshair();
+    resizeCrosshair();
 };
 
 // Zoom keeping the selection center (if any) fixed.
@@ -80,7 +80,7 @@ const zoomOnSelection = deltaZoom => {
 
 const resetZoom = () => {
     paper.project.view.zoom = .5;
-    _resizeCrosshair();
+    resizeCrosshair();
     clampViewBounds();
 };
 
@@ -106,7 +106,7 @@ const zoomToFit = isBitmap => {
         if (ratio < 1) {
             paper.view.center = bounds.center;
             paper.view.zoom = paper.view.zoom / ratio;
-            _resizeCrosshair();
+            resizeCrosshair();
             clampViewBounds();
         }
     }
@@ -121,6 +121,7 @@ export {
     clampViewBounds,
     pan,
     resetZoom,
+    resizeCrosshair,
     zoomOnSelection,
     zoomOnFixedPoint,
     zoomToFit


### PR DESCRIPTION
The bug was that when you opened a costume in the paint editor, zoomed in, switched tabs, switched back, and then dragged something to make the crosshair visible, the crosshair was super huge!

The case where you leave and come back to a costume you already opened is the case where we store the zoom level as a matrix. We were forgetting to readjust the crosshair size in that case.