### PR TITLE
Clear undo state when imageId is changed while unmounted

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -7,7 +7,7 @@ import Formats from '../lib/format';
 import log from '../log/log';
 
 import {performSnapshot} from '../helper/undo';
-import {undoSnapshot, clearUndoState, switchCostume} from '../reducers/undo';
+import {undoSnapshot, clearUndoState, changeImageId} from '../reducers/undo';
 import {isGroup, ungroupItems} from '../helper/group';
 import {clearRaster, getRaster, setupLayers} from '../helper/layer';
 import {clearSelectedItems} from '../reducers/selected-items';
@@ -112,7 +112,7 @@ class PaperCanvas extends React.Component {
         this.props.clearSelectedItems();
         this.props.clearHoveredItem();
         this.props.clearPasteOffset();
-        this.props.switchCostume(newImageId);
+        this.props.changeImageId(newImageId);
         this.importImage(format, image, rotationCenterX, rotationCenterY);
     }
     importImage (format, image, rotationCenterX, rotationCenterY) {
@@ -302,7 +302,7 @@ PaperCanvas.propTypes = {
     rotationCenterY: PropTypes.number,
     saveZoomLevel: PropTypes.func.isRequired,
     setZoomLevelId: PropTypes.func.isRequired,
-    switchCostume: PropTypes.func.isRequired,
+    changeImageId: PropTypes.func.isRequired,
     undoSnapshot: PropTypes.func.isRequired,
     updateViewBounds: PropTypes.func.isRequired,
     zoomLevelId: PropTypes.string,
@@ -342,8 +342,8 @@ const mapDispatchToProps = dispatch => ({
     setZoomLevelId: zoomLevelId => {
         dispatch(setZoomLevelId(zoomLevelId));
     },
-    switchCostume: imageId => {
-        dispatch(switchCostume(imageId));
+    changeImageId: imageId => {
+        dispatch(changeImageId(imageId));
     },
     updateViewBounds: matrix => {
         dispatch(updateViewBounds(matrix));

--- a/src/reducers/undo.js
+++ b/src/reducers/undo.js
@@ -4,7 +4,7 @@ const UNDO = 'scratch-paint/undo/UNDO';
 const REDO = 'scratch-paint/undo/REDO';
 const SNAPSHOT = 'scratch-paint/undo/SNAPSHOT';
 const CLEAR = 'scratch-paint/undo/CLEAR';
-const SWITCH_COSTUME = 'scratch-paint/undo/SWITCH_COSTUME';
+const CHANGE_IMAGE_ID = 'scratch-paint/undo/CHANGE_IMAGE_ID';
 const MAX_STACK_SIZE = 100;
 const initialState = {
     stack: [],
@@ -68,7 +68,7 @@ const reducer = function (state, action) {
             });
     case CLEAR:
         return initialState;
-    case SWITCH_COSTUME:
+    case CHANGE_IMAGE_ID:
         return Object.assign({}, state, {imageId: action.imageId});
     default:
         return state;
@@ -107,9 +107,9 @@ const clearUndoState = function () {
         type: CLEAR
     };
 };
-const switchCostume = function (imageId) {
+const changeImageId = function (imageId) {
     return {
-        type: SWITCH_COSTUME,
+        type: CHANGE_IMAGE_ID,
         imageId
     };
 };
@@ -120,7 +120,7 @@ export {
     redo,
     undoSnapshot,
     clearUndoState,
-    switchCostume,
+    changeImageId,
     MAX_STACK_SIZE,
     UNDO,
     REDO

--- a/src/reducers/undo.js
+++ b/src/reducers/undo.js
@@ -4,10 +4,12 @@ const UNDO = 'scratch-paint/undo/UNDO';
 const REDO = 'scratch-paint/undo/REDO';
 const SNAPSHOT = 'scratch-paint/undo/SNAPSHOT';
 const CLEAR = 'scratch-paint/undo/CLEAR';
+const SWITCH_COSTUME = 'scratch-paint/undo/SWITCH_COSTUME';
 const MAX_STACK_SIZE = 100;
 const initialState = {
     stack: [],
-    pointer: -1
+    pointer: -1,
+    imageId: ''
 };
 
 const reducer = function (state, action) {
@@ -18,19 +20,25 @@ const reducer = function (state, action) {
             log.warn(`Can't undo, undo stack is empty`);
             return state;
         }
-        return {
-            stack: state.stack,
-            pointer: state.pointer - 1
-        };
+        return Object.assign(
+            {},
+            state,
+            {
+                stack: state.stack,
+                pointer: state.pointer - 1
+            });
     case REDO:
         if (state.pointer <= -1 || state.pointer === state.stack.length - 1) {
             log.warn(`Can't redo, redo stack is empty`);
             return state;
         }
-        return {
-            stack: state.stack,
-            pointer: state.pointer + 1
-        };
+        return Object.assign(
+            {},
+            state,
+            {
+                stack: state.stack,
+                pointer: state.pointer + 1
+            });
     case SNAPSHOT:
         if (!action.snapshot) {
             log.warn(`Couldn't create undo snapshot, no data provided`);
@@ -38,19 +46,30 @@ const reducer = function (state, action) {
         }
         // Overflowed or about to overflow
         if (state.pointer >= MAX_STACK_SIZE - 1) {
-            return {
-                // Make a stack of size MAX_STACK_SIZE, cutting off the oldest snapshots.
-                stack: state.stack.slice(state.pointer - MAX_STACK_SIZE + 2, state.pointer + 1).concat(action.snapshot),
-                pointer: MAX_STACK_SIZE - 1
-            };
+            return Object.assign(
+                {},
+                state,
+                {
+                    // Make a stack of size MAX_STACK_SIZE, cutting off the oldest snapshots.
+                    stack: state.stack.slice(
+                        state.pointer - MAX_STACK_SIZE + 2,
+                        state.pointer + 1
+                    ).concat(action.snapshot),
+                    pointer: MAX_STACK_SIZE - 1
+                });
         }
-        return {
-            // Performing an action clears the redo stack
-            stack: state.stack.slice(0, state.pointer + 1).concat(action.snapshot),
-            pointer: state.pointer + 1
-        };
+        return Object.assign(
+            {},
+            state,
+            {
+                // Performing an action clears the redo stack
+                stack: state.stack.slice(0, state.pointer + 1).concat(action.snapshot),
+                pointer: state.pointer + 1
+            });
     case CLEAR:
         return initialState;
+    case SWITCH_COSTUME:
+        return Object.assign({}, state, {imageId: action.imageId});
     default:
         return state;
     }
@@ -88,6 +107,12 @@ const clearUndoState = function () {
         type: CLEAR
     };
 };
+const switchCostume = function (imageId) {
+    return {
+        type: SWITCH_COSTUME,
+        imageId
+    };
+};
 
 export {
     reducer as default,
@@ -95,6 +120,7 @@ export {
     redo,
     undoSnapshot,
     clearUndoState,
+    switchCostume,
     MAX_STACK_SIZE,
     UNDO,
     REDO


### PR DESCRIPTION
### Resolves
Resolves LLK/scratch-desktop#105

### Proposed Changes
This adds new state, imageId. This is kept even if the paint editor is unmounted (by changing the tabs). `componentWillReceiveProps` now checks if the state imageId is not same as `newProps.imageId`, and calls switchCostume. imageId state is set in switchCostume.

### Reason for Changes
In some cases, the costume switches while the paint editor is unmounted. Previously when the paint editor is remounted it forgets the fact that it previously had different imageId, thus not calling the switchCostume (where undo stack is reset). ScratchPaintReducer stats are unaffected by unmounting, so the current imageId had to be stored there.

### Test Coverage
Maybe for the reducer? (not pushed yet)