### PR TITLE
Tighten bitmap selection bounds

### DIFF
--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -320,11 +320,18 @@ const columnBlank_ = function (imageData, width, x, top, bottom) {
     return true;
 };
 
-// Adapted from Tim Down's https://gist.github.com/timdown/021d9c8f2aabc7092df564996f5afbbf
-// Get bounds, trimming transparent pixels from edges.
-const getHitBounds = function (raster) {
-    const width = raster.width;
-    const imageData = raster.getImageData(raster.bounds);
+/**
+ * Get bounds around the contents of a raster, trimming transparent pixels from edges.
+ * Adapted from Tim Down's https://gist.github.com/timdown/021d9c8f2aabc7092df564996f5afbbf
+ * @param {paper.Raster} raster The raster to get the bounds around
+ * @param {paper.Rectangle} [rect] Optionally, an alternative bounding rectangle to limit the check to.
+ * @returns {paper.Rectangle} The bounds around the opaque area of the passed raster
+ * (or opaque within the passed rectangle)
+ */
+const getHitBounds = function (raster, rect) {
+    const bounds = rect || raster.bounds;
+    const width = bounds.width;
+    const imageData = raster.getImageData(bounds);
     let top = 0;
     let bottom = imageData.height;
     let left = 0;
@@ -343,7 +350,7 @@ const getHitBounds = function (raster) {
         left = right = imageData.width / 2;
     }
 
-    return new paper.Rectangle(left, top, right - left, bottom - top);
+    return new paper.Rectangle(left + bounds.left, top + bounds.top, right - left, bottom - top);
 };
 
 const trim_ = function (raster) {

--- a/src/helper/selection-tools/selection-box-tool.js
+++ b/src/helper/selection-tools/selection-box-tool.js
@@ -74,8 +74,7 @@ class SelectionBoxTool {
                 context.clearRect(rect.x, rect.y, rect.width, rect.height);
                 this.setSelectedItems();
             }
-        }
-        if (this.selectionRect) {
+
             // Remove dotted rectangle
             this.selectionRect.remove();
             this.selectionRect = null;

--- a/src/helper/selection-tools/selection-box-tool.js
+++ b/src/helper/selection-tools/selection-box-tool.js
@@ -3,6 +3,7 @@ import {rectSelect} from '../guides';
 import {clearSelection, processRectangularSelection} from '../selection';
 import {getRaster} from '../layer';
 import {ART_BOARD_WIDTH, ART_BOARD_HEIGHT} from '../view';
+import {getHitBounds} from '../../helper/bitmap';
 
 /** Tool to handle drag selection. A dotted line box appears and everything enclosed is selected. */
 class SelectionBoxTool {
@@ -44,8 +45,8 @@ class SelectionBoxTool {
     }
     onMouseUpBitmap (event) {
         if (event.event.button > 0) return; // only first mouse button
-        if (this.selectionRect && this.selectionRect.bounds.intersects(getRaster().bounds)) {
-            const rect = new paper.Rectangle({
+        if (this.selectionRect) {
+            let rect = new paper.Rectangle({
                 from: new paper.Point(
                     Math.max(0, Math.round(this.selectionRect.bounds.topLeft.x)),
                     Math.max(0, Math.round(this.selectionRect.bounds.topLeft.y))),
@@ -53,6 +54,9 @@ class SelectionBoxTool {
                     Math.min(ART_BOARD_WIDTH, Math.round(this.selectionRect.bounds.bottomRight.x)),
                     Math.min(ART_BOARD_HEIGHT, Math.round(this.selectionRect.bounds.bottomRight.y)))
             });
+
+            // Trim/tighten selection bounds inwards to only the opaque region, excluding transparent pixels
+            rect = getHitBounds(getRaster(), rect);
 
             if (rect.area) {
                 // Pull selected raster to active layer


### PR DESCRIPTION
### Resolves

Resolves #959
Resolves #979

### Proposed Changes

This PR tightens the areas selected by the bitmap selection tool to only include opaque pixels:
![Peek 2020-03-27 14-14](https://user-images.githubusercontent.com/25993062/77787076-4f0c3880-7035-11ea-8ade-e120c9090fec.gif)

As a supporting change, it modifies `getHitBounds` to optionally include a sub-rectangle of the passed raster as a parameter.

### Reason for Changes

See linked issues