### PR TITLE
Adjust reshape mode handle tolerance

### DIFF
--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -33,6 +33,18 @@ const ReshapeModes = keyMirror({
 class ReshapeTool extends paper.Tool {
     /** Distance within which mouse is considered to be hitting an item */
     static get TOLERANCE () {
+        return ReshapeTool.HANDLE_RADIUS + ReshapeTool.HANDLE_PADDING;
+    }
+    /**
+     * Units of padding around the visible handle area that will still register clicks as "touching the handle"
+     */
+    static get HANDLE_PADDING () {
+        return 1;
+    }
+    /**
+     * Handles' radius, including the stroke
+     */
+    static get HANDLE_RADIUS () {
         return 5.25;
     }
     /** Clicks registered within this amount of time are registered as double clicks */
@@ -74,9 +86,10 @@ class ReshapeTool extends paper.Tool {
         this.onKeyUp = this.handleKeyUp;
         this.onKeyDown = this.handleKeyDown;
 
-        // A handle's size is given in diameter, and each handle has a 2.5-pixel stroke that isn't part of its size.
+        // A handle's size is given in diameter, and each handle has a 2.5-pixel stroke that isn't part of its size:
+        // https://github.com/LLK/paper.js/blob/a187e4c81cc63f3d48c5097b9a9fbddde9f057da/src/item/Item.js#L4480
         // Size the handles such that clicking on either the stroke or the handle itself will be registered as a drag
-        paper.settings.handleSize = (ReshapeTool.TOLERANCE * 2) - 2.5;
+        paper.settings.handleSize = (ReshapeTool.HANDLE_RADIUS * 2) - 2.5;
     }
     /**
      * Returns the hit options for segments to use when conducting hit tests. Segments are only visible

--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -33,7 +33,7 @@ const ReshapeModes = keyMirror({
 class ReshapeTool extends paper.Tool {
     /** Distance within which mouse is considered to be hitting an item */
     static get TOLERANCE () {
-        return 4;
+        return 5.25;
     }
     /** Clicks registered within this amount of time are registered as double clicks */
     static get DOUBLE_CLICK_MILLIS () {

--- a/src/helper/selection-tools/reshape-tool.js
+++ b/src/helper/selection-tools/reshape-tool.js
@@ -74,7 +74,9 @@ class ReshapeTool extends paper.Tool {
         this.onKeyUp = this.handleKeyUp;
         this.onKeyDown = this.handleKeyDown;
 
-        paper.settings.handleSize = 8;
+        // A handle's size is given in diameter, and each handle has a 2.5-pixel stroke that isn't part of its size.
+        // Size the handles such that clicking on either the stroke or the handle itself will be registered as a drag
+        paper.settings.handleSize = (ReshapeTool.TOLERANCE * 2) - 2.5;
     }
     /**
      * Returns the hit options for segments to use when conducting hit tests. Segments are only visible


### PR DESCRIPTION
### Resolves

Resolves #691
Resolves #737

### Proposed Changes

This PR changes the handle size used by the reshape tool to match the tool's `TOLERANCE` constant such that clicking anywhere on a handle (including the handle's stroke/outline) will count as clicking the handle.

It also increases `TOLERANCE` to 5 so that the now-dynamically-sized handles retain their previous size.

### Reason for Changes

This makes handles' clickable regions match their appearance on-screen, making it much easier to move points around.