### PR TITLE
Improve broad brush handling

### DIFF
--- a/src/helper/blob-tools/broad-brush-helper.js
+++ b/src/helper/blob-tools/broad-brush-helper.js
@@ -79,7 +79,6 @@ class BroadBrushHelper {
                 this.endCaps.push(this.union(circ, this.union(rect, rect2)));
             }
         }
-        this.lastVec = event.delta;
         step.angle += 90;
 
         // Move the first point out away from the drag so that the end of the path is rounded
@@ -98,12 +97,27 @@ class BroadBrushHelper {
             this.finalPath.add(new paper.Segment(this.lastPoint.add(step)));
         }
 
+        // Update angle of the last brush step's points to match the average angle of the last mouse vector and this
+        // mouse vector (aka the vertex normal).
+        if (this.lastVec) {
+            const lastNormal = this.lastVec.normalize(options.brushSize / 2).rotate(90);
+            const averageNormal = new paper.Point(
+                lastNormal.x + step.x,
+                lastNormal.y + step.y
+            ).normalize(options.brushSize / 2);
+
+            this.finalPath.segments[0].point = this.lastPoint.subtract(averageNormal);
+            this.finalPath.segments[this.finalPath.segments.length - 1].point = this.lastPoint.add(averageNormal);
+        }
+
         this.finalPath.add(event.point.add(step));
         this.finalPath.insert(0, event.point.subtract(step));
 
         if (this.finalPath.segments.length > this.smoothed + (this.smoothingThreshold * 2)) {
             this.simplify(1);
         }
+
+        this.lastVec = event.delta;
         this.lastPoint = event.point;
     }
 

--- a/src/helper/blob-tools/broad-brush-helper.js
+++ b/src/helper/blob-tools/broad-brush-helper.js
@@ -38,7 +38,7 @@ class BroadBrushHelper {
         tool.minDistance = Math.min(5, Math.max(2 / paper.view.zoom, options.brushSize / 2));
         tool.maxDistance = options.brushSize;
         if (event.event.button > 0) return; // only first mouse button
-        
+
         this.finalPath = new paper.Path.Circle({
             center: event.point,
             radius: options.brushSize / 2
@@ -46,7 +46,7 @@ class BroadBrushHelper {
         styleBlob(this.finalPath, options);
         this.lastPoint = event.point;
     }
-    
+
     onBroadMouseDrag (event, tool, options) {
         this.steps++;
         const step = (event.delta).normalize(options.brushSize / 2);
@@ -97,12 +97,8 @@ class BroadBrushHelper {
             this.finalPath.insert(0, new paper.Segment(this.lastPoint.subtract(step)));
             this.finalPath.add(new paper.Segment(this.lastPoint.add(step)));
         }
-        const top = event.middlePoint.add(step);
-        const bottom = event.middlePoint.subtract(step);
 
-        this.finalPath.add(top);
         this.finalPath.add(event.point.add(step));
-        this.finalPath.insert(0, bottom);
         this.finalPath.insert(0, event.point.subtract(step));
 
         if (this.finalPath.segments.length > this.smoothed + (this.smoothingThreshold * 2)) {
@@ -220,7 +216,7 @@ class BroadBrushHelper {
             this.finalPath.remove();
             this.finalPath = newPath;
         }
-        
+
         // Try to merge end caps
         for (const cap of this.endCaps) {
             const temp = this.union(this.finalPath, cap);

--- a/src/helper/blob-tools/broad-brush-helper.js
+++ b/src/helper/blob-tools/broad-brush-helper.js
@@ -34,6 +34,7 @@ class BroadBrushHelper {
     onBroadMouseDown (event, tool, options) {
         this.steps = 0;
         this.smoothed = 0;
+        this.lastVec = null;
         tool.minDistance = Math.min(5, Math.max(2 / paper.view.zoom, options.brushSize / 2));
         tool.maxDistance = options.brushSize;
         if (event.event.button > 0) return; // only first mouse button

--- a/src/helper/blob-tools/broad-brush-helper.js
+++ b/src/helper/blob-tools/broad-brush-helper.js
@@ -196,10 +196,15 @@ class BroadBrushHelper {
             return this.finalPath;
         }
 
+        let delta = this.lastVec;
+
         // If the mouse up is at the same point as the mouse drag event then we need
         // the second to last point to get the right direction vector for the end cap
         if (!event.point.equals(this.lastPoint)) {
-            const step = event.delta.normalize(options.brushSize / 2);
+            // The given event.delta is the difference between the mouse down coords and the mouse up coords,
+            // but we want the difference between the last mouse drag coords and the mouse up coords.
+            delta = event.point.subtract(this.lastPoint);
+            const step = delta.normalize(options.brushSize / 2);
             step.angle += 90;
 
             const top = event.point.add(step);
@@ -210,7 +215,7 @@ class BroadBrushHelper {
 
         // Simplify before adding end cap so cap doesn't get warped
         this.simplify(1);
-        const handleVec = event.delta.normalize(options.brushSize / 2);
+        const handleVec = delta.normalize(options.brushSize / 2);
         this.finalPath.add(new paper.Segment(
             event.point.add(handleVec),
             handleVec.rotate(90),


### PR DESCRIPTION
### Resolves

Resolves #715
Resolves #320

### Proposed Changes

- Clear `BroadBrushHelper.lastVec` in `onBroadMouseDown`
- Don't add both `event.middlePoint` and `event.point` to the brush path in `onBroadMouseMove`
- Set the brush path angle to the proper vertex normal
- Use the correct mouse delta in `onBroadMouseUp`

### Reason for Changes

Taken together, these changes significantly improve the quality of brush strokes created by the broad brush algorithm:

- Clear `BroadBrushHelper.lastVec` in `onBroadMouseDown`
  - `onBroadMouseMove` checks for the existence of `lastVec` to determine whether to add end caps. If `lastVec` is not cleared, it will hold the value from the previous brush stroke, causing an erroneous end cap to appear at an incorrect angle at the beginning of every brush stroke after the first.

- Don't add both `event.middlePoint` and `event.point` to the brush path in `onBroadMouseMove`
  - This appears to be the cause of most of the "wrinkles" in the brush stroke:
  - ![image](https://user-images.githubusercontent.com/25993062/79707601-0e49bd00-828b-11ea-8934-3f612d6f3018.png)
  - `event.middlePoint` is just a linear interpolation between the last event point and `event.point`, so it doesn't need to be added to the brush path.

- Set the brush path angle to the proper vertex normal
  - This is hard to explain. Previously, the brush's points were expanded outwards at the angle of the mouse delta event before them, like so:
  - ![image](https://user-images.githubusercontent.com/25993062/79707679-4cdf7780-828b-11ea-9196-475e2e5b56e7.png)
  - Now they take the average angle of the deltas before and after them:
  - ![image](https://user-images.githubusercontent.com/25993062/79707823-b9f30d00-828b-11ea-8ffc-dd3eef40658f.png)
  - This also makes the brush edges less jagged.

- Use the correct mouse delta in `onBroadMouseUp`
  - The mouse up event's `delta` refers to the difference between the mouse down coordinates and the mouse up coordinates, but we want the difference between the last mouse *drag* coordinates and the mouse up coordinates, in order to properly angle the end cap.
