### PR TITLE
Remove compound path TODOs from blob.js

### DIFF
--- a/src/helper/blob-tools/blob.js
+++ b/src/helper/blob-tools/blob.js
@@ -272,7 +272,6 @@ class Blobbiness {
         }
 
         for (let i = items.length - 1; i >= 0; i--) {
-            // TODO handle compound paths
             if (items[i] instanceof paper.Path && (!items[i].fillColor || items[i].fillColor._alpha === 0)) {
                 // Gather path segments
                 const subpaths = [];
@@ -305,7 +304,6 @@ class Blobbiness {
 
             // Gather path segments
             const subpaths = [];
-            // TODO: Handle compound path
             if (items[i] instanceof paper.Path && !items[i].closed) {
                 const firstSeg = items[i].clone();
                 const intersections = firstSeg.getIntersections(lastPath);


### PR DESCRIPTION
### Resolves

#119, I guess?

### Proposed Changes

Per [this comment](https://github.com/LLK/scratch-paint/pull/921#discussion_r414876979), this PR removes the `TODO` comments about handling compound paths in the `mergeEraser` code.

### Reason for Changes

Handling compound paths is now done properly, so the comments are no longer needed.