### PR TITLE
Fix Scratch paint building in node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,9 @@ env:
 cache:
   directories:
   - node_modules
-addons:
-  apt:
-    packages:
-    - libcairo2-dev
-    - libpango1.0-dev
-    - libssl-dev
-    - libjpeg62-dev
-    - libgif-dev
 install:
 - npm --production=false install
 - npm --production=false update
-- npm install --no-save canvas@1.6.11
 script: npm run $NPM_SCRIPT
 jobs:
     include:

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.22.0",
-    "canvas-prebuilt": "^1.6.11",
     "css-loader": "3.4.0",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",
@@ -69,6 +68,7 @@
     "gh-pages": "github:rschamp/gh-pages#publish-branch-to-subfolder",
     "html-webpack-plugin": "3.2.0",
     "jest": "^22.2.2",
+    "jest-canvas-mock": "^2.2.0",
     "lodash.defaultsdeep": "4.6.1",
     "mkdirp": "^1.0.3",
     "postcss-import": "^12.0.0",
@@ -103,7 +103,8 @@
   "jest": {
     "setupFiles": [
       "raf/polyfill",
-      "<rootDir>/test/helpers/enzyme-setup.js"
+      "<rootDir>/test/helpers/enzyme-setup.js",
+      "jest-canvas-mock"
     ],
     "testURL": "http://localhost",
     "moduleNameMapper": {


### PR DESCRIPTION
### Resolves
https://github.com/LLK/scratch-paint/issues/1009

### Proposed Changes
Switch from canvas-prebuilt to jest-canvas-mock

### Reason for Changes
canvas-prebuilt no longer supported in Node 10

### Test Coverage
Ran tests