### PR TITLE
Revert "fix(package): update @scratch/paper to version 0.11.20200424212514"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "git+ssh://git@github.com/LLK/scratch-paint.git"
   },
   "dependencies": {
-    "@scratch/paper": "0.11.20200424212514",
+    "@scratch/paper": "0.11.20190729152410",
     "classnames": "2.2.5",
     "keymirror": "0.1.1",
     "lodash.bindall": "4.4.0",


### PR DESCRIPTION
Reverts LLK/scratch-paint#1015

This update broke editing points in the reshape tool. The paint editor canvas stops updating.