### PR TITLE
Move canvas dimension rounding to recalibrateSize

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -304,6 +304,9 @@ class PaperCanvas extends React.Component {
         // Sets the size that Paper thinks the canvas is to the size the canvas element actually is.
         // When these are out of sync, the mouse events in the paint editor don't line up correctly.
         return window.setTimeout(() => {
+            // If the component unmounts, the canvas will be removed from the page, detaching paper.view.
+            // This could also be called before paper.view exists.
+            // In either case, return early if so without running the callback.
             if (!paper.view) return;
             // Prevent blurriness caused if the "CSS size" of the element is a float--
             // setting canvas dimensions to floats floors them, but we need to round instead


### PR DESCRIPTION
### Resolves

Resolves #1049

### Proposed Changes

Change `PaperCanvas`'s `recalibrateSize` function to round the dimensions of the canvas, as was previously done when importing an SVG.

Also change it to take a callback, which is now passed when importing an SVG in order to initialize the SVG after the canvas has been resized. 

### Reason for Changes

In my review, I mistakenly only caught one place where the canvas was being resized--this fixes the other place and ensures that all canvas resizes now go through that path, preventing canvas blurriness.
