### PR TITLE
Add default rotation center for bitmap images

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ SVGs of up to size 480 x 360 will fit into the view window of the paint editor, 
 
 `imageFormat`: 'svg', 'png', or 'jpg'. Other formats are currently not supported.
 
-`rotationCenterX`: x coordinate relative to the top left corner of the sprite of the point that should be centered.
+`rotationCenterX`: x coordinate relative to the top left corner of the sprite of the point that should be centered. If left undefined, image will be horizontally centered.
 
-`rotationCenterY`: y coordinate relative to the top left corner of the sprite of the point that should be centered.
+`rotationCenterY`: y coordinate relative to the top left corner of the sprite of the point that should be centered. If left undefined, image will be vertcally centered.
 
 `rtl`: True if the paint editor should be laid out right to left (meant for right to left languages)
 

--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -148,6 +148,13 @@ class PaperCanvas extends React.Component {
                 if (!this.queuedImageToLoad) return;
                 this.queuedImageToLoad = null;
 
+                if (typeof rotationCenterX === 'undefined') {
+                    rotationCenterX = imgElement.width / 2;
+                }
+                if (typeof rotationCenterY === 'undefined') {
+                    rotationCenterY = imgElement.height / 2;
+                }
+
                 getRaster().drawImage(
                     imgElement,
                     (ART_BOARD_WIDTH / 2) - rotationCenterX,


### PR DESCRIPTION
### Resolves
https://github.com/LLK/scratch-paint/issues/1078

### Proposed Changes
If no rotation center is passed in, default to the center of the canvas

### Reason for Changes
it's better than nothing appearing

### Test Coverage
manual