### PR TITLE
Bump grid opacity

### DIFF
--- a/src/helper/layer.js
+++ b/src/helper/layer.js
@@ -298,7 +298,7 @@ const _makeBackgroundGuideLayer = function (format) {
     const vBackground = _makeBackgroundPaper(
         MAX_WORKSPACE_BOUNDS.width / CHECKERBOARD_SIZE,
         (MAX_WORKSPACE_BOUNDS.height / CHECKERBOARD_SIZE) + 1,
-        '#0062ff', 0.1);
+        '#D9E3F2', 0.55);
     vBackground.position = CENTER;
     vBackground.scaling = new paper.Point(CHECKERBOARD_SIZE, CHECKERBOARD_SIZE);
 
@@ -311,7 +311,7 @@ const _makeBackgroundGuideLayer = function (format) {
     const bitmapBackground = _makeBackgroundPaper(
         ART_BOARD_WIDTH / CHECKERBOARD_SIZE,
         ART_BOARD_HEIGHT / CHECKERBOARD_SIZE,
-        '#0062ff', 0.1);
+        '#D9E3F2', 0.55);
     bitmapBackground.position = CENTER;
     bitmapBackground.scaling = new paper.Point(CHECKERBOARD_SIZE, CHECKERBOARD_SIZE);
     bitmapBackground.guide = true;

--- a/src/helper/layer.js
+++ b/src/helper/layer.js
@@ -298,7 +298,7 @@ const _makeBackgroundGuideLayer = function (format) {
     const vBackground = _makeBackgroundPaper(
         MAX_WORKSPACE_BOUNDS.width / CHECKERBOARD_SIZE,
         (MAX_WORKSPACE_BOUNDS.height / CHECKERBOARD_SIZE) + 1,
-        '#0062ff', 0.05);
+        '#0062ff', 0.1);
     vBackground.position = CENTER;
     vBackground.scaling = new paper.Point(CHECKERBOARD_SIZE, CHECKERBOARD_SIZE);
 
@@ -311,7 +311,7 @@ const _makeBackgroundGuideLayer = function (format) {
     const bitmapBackground = _makeBackgroundPaper(
         ART_BOARD_WIDTH / CHECKERBOARD_SIZE,
         ART_BOARD_HEIGHT / CHECKERBOARD_SIZE,
-        '#0062ff', 0.05);
+        '#0062ff', 0.1);
     bitmapBackground.position = CENTER;
     bitmapBackground.scaling = new paper.Point(CHECKERBOARD_SIZE, CHECKERBOARD_SIZE);
     bitmapBackground.guide = true;


### PR DESCRIPTION
### Resolves
Resolves #1082 

### Proposed Changes
Bump the opacity of the grid
before
<img width="986" alt="Screen Shot 2020-05-24 at 23 06 36" src="https://user-images.githubusercontent.com/2855464/82774587-3ccf3080-9e13-11ea-8551-0115ba1765fe.png">
<img width="581" alt="Screen Shot 2020-05-24 at 23 09 48" src="https://user-images.githubusercontent.com/2855464/82774728-b0713d80-9e13-11ea-96db-b59a2b37c42e.png">

after
<img width="843" alt="Screen Shot 2020-06-01 at 20 19 12" src="https://user-images.githubusercontent.com/2855464/83466482-33fae200-a445-11ea-8989-e94f4b020288.png">
<img width="891" alt="Screen Shot 2020-06-01 at 20 19 05" src="https://user-images.githubusercontent.com/2855464/83466483-33fae200-a445-11ea-906d-61b979b090cd.png">


### Reason for Changes
Make the grid more visible

### Test Coverage
Tested manually