### PR TITLE
Delete item.data.origPos instead of setting it to null

### DIFF
--- a/src/helper/selection-tools/move-tool.js
+++ b/src/helper/selection-tools/move-tool.js
@@ -206,10 +206,10 @@ class MoveTool {
         let moved = false;
         // resetting the items origin point for the next usage
         for (const item of this.selectedItems) {
-            if (item.data && item.data.origPos && !item.position.equals(item.data.origPos)) {
-                moved = true;
+            if (item.data.origPos) {
+                if (!item.position.equals(item.data.origPos)) moved = true;
+                delete item.data.origPos;
             }
-            item.data.origPos = null;
         }
         this.selectedItems = null;
         this.selectionCenter = null;


### PR DESCRIPTION
### Resolves

Resolves #1099

### Proposed Changes

This PR changes the move tool to delete `item.data.origPos` on its selected items when finished dragging, as opposed to setting it to `null` as it previously did.

### Reason for Changes

Dragging a vector shape causes the `MoveTool` to set the `origPos` property on that item's `data`. Once the dragging is done, `origPos` was previously then set to `null`.

However, since it was still present in the item's `data`, paper.js was serializing it into the saved SVG.

Now, the `MoveTool` deletes the `origPos` property entirely. This means that paper.js won't serialize it, decreasing the size of saved SVGs.

### Test Coverage

Tested manually