### PR TITLE
Stop setting item.data.origRot

### DIFF
--- a/src/helper/selection-tools/rotate-tool.js
+++ b/src/helper/selection-tools/rotate-tool.js
@@ -37,10 +37,6 @@ class RotateTool {
 
         for (let i = 0; i < this.rotItems.length; i++) {
             const item = this.rotItems[i];
-            
-            if (!item.data.origRot) {
-                item.data.origRot = item.rotation;
-            }
 
             item.rotate(rotAngle - this.prevRot, this.rotGroupPivot);
         }
@@ -49,7 +45,7 @@ class RotateTool {
     }
     onMouseUp (event) {
         if (event.event.button > 0) return; // only first mouse button
-        
+
         this.rotItems.length = 0;
         this.rotGroupPivot = null;
         this.prevRot = 90;


### PR DESCRIPTION
### Resolves

Resolves #1099

### Proposed Changes

This PR stops setting `item.data.origRot` in the `RotateTool`.

### Reason for Changes

`item.data.origRot` was never being read from, but was being serialized and taking up extra space in the exported SVG.

### Test Coverage

Tested manually