### PR TITLE
Fix LiveInputHOC in Firefox

### DIFF
--- a/src/components/forms/live-input-hoc.jsx
+++ b/src/components/forms/live-input-hoc.jsx
@@ -14,11 +14,16 @@ export default function (Input) {
             bindAll(this, [
                 'handleChange',
                 'handleKeyPress',
-                'handleFlush'
+                'handleFlush',
+                'handleFocus'
             ]);
             this.state = {
                 value: null
             };
+
+            // Track whether the input is currently focused.
+            // This is a class variable because it doesn't need to trigger re-renders
+            this.focused = false;
         }
         handleKeyPress (e) {
             if (e.key === 'Enter') {
@@ -28,6 +33,11 @@ export default function (Input) {
         }
         handleFlush () {
             this.setState({value: null});
+            this.focused = false;
+        }
+        handleFocus (e) {
+            this.setState({value: e.target.value});
+            this.focused = true;
         }
         handleChange (e) {
             const isNumeric = typeof this.props.value === 'number';
@@ -42,7 +52,10 @@ export default function (Input) {
                 }
                 this.props.onSubmit(val);
             }
-            this.setState({value: e.target.value});
+            // In Firefox, clicking the arrow buttons on a number input changes its value without focusing it.
+            // Make sure that we only set this.state.value (which overrides this.props.value) if the input is actually
+            // focused.
+            if (this.focused) this.setState({value: e.target.value});
         }
         render () {
             const liveValue = this.state.value === null ? this.props.value : this.state.value;
@@ -51,6 +64,7 @@ export default function (Input) {
                     {...this.props}
                     value={liveValue}
                     onBlur={this.handleFlush}
+                    onFocus={this.handleFocus}
                     onChange={this.handleChange}
                     onKeyPress={this.handleKeyPress}
                 />


### PR DESCRIPTION
### Resolves

Resolves #1111

### Proposed Changes

This PR adds a new `focused` property to `LiveInputHOC` that tracks whether the input is currently focused. It also changes `LiveInputHOC` to only set its state's `value` to its input's value if the input is currently focused.

### Reason for Changes

The LiveInputHOC is supposed to allow you to type values into a text input and only trigger an update when you defocus it. It does this by setting its state's `value` to its input's value whenever its input is changed, clearing its state's `value` whenever its input is unfocused/clicked away from ("blurred"), and always using its state's `value` over the `value` passed in from `props` when rendering.

However, Firefox allows you to change a number input's value without focusing it by clicking the arrow buttons. This means that handleChange was setting the component's state `value`, but because it was never focused, it was never unfocused ("blurred") and hence `handleFlush` (called when the input is "blurred") never came along to clear `value` from the component's state.

This resulted in the component being "stuck" using the stored `value` if you clicked on the arrow buttons to change the input's value.

### Test Coverage

Tested manually