### PR TITLE
Undo/Redo should not be reversed in RTL languages

### DIFF
--- a/src/components/fixed-tools/fixed-tools.jsx
+++ b/src/components/fixed-tools/fixed-tools.jsx
@@ -125,11 +125,11 @@ const FixedToolsComponent = props => {
                                 }
                             )
                         }
-                        disabled={undoDisabled}
-                        onClick={props.onUndo}
+                        disabled={props.rtl ? redoDisabled : undoDisabled}
+                        onClick={props.rtl ? props.onRedo : props.onUndo}
                     >
                         <img
-                            alt={props.intl.formatMessage(messages.undo)}
+                            alt={props.intl.formatMessage(props.rtl ? messages.redo : messages.undo)}
                             className={classNames(
                                 styles.buttonGroupButtonIcon,
                                 styles.undoIcon
@@ -147,11 +147,11 @@ const FixedToolsComponent = props => {
                                 }
                             )
                         }
-                        disabled={redoDisabled}
-                        onClick={props.onRedo}
+                        disabled={props.rtl ? undoDisabled : redoDisabled}
+                        onClick={props.rtl ? props.onUndo : props.onRedo}
                     >
                         <img
-                            alt={props.intl.formatMessage(messages.redo)}
+                            alt={props.intl.formatMessage(props.rtl ? messages.undo : messages.redo)}
                             className={styles.buttonGroupButtonIcon}
                             draggable={false}
                             src={redoIcon}


### PR DESCRIPTION
### Resolves

Fixes #987 

According to my research imagery needs to stay in position but functionality and labeling needs to be reversed in RTL.

[link to article](https://medium.com/@giladalmosnino/ux-best-practices-for-bi-directional-languages-9bd7b96dc8c2)

### Reason for Changes

See issue

### Test Coverage

I did not add a test