### PR TITLE
Fix color button turning white when it shouldn't

### DIFF
--- a/src/components/color-button/color-button.jsx
+++ b/src/components/color-button/color-button.jsx
@@ -11,7 +11,7 @@ import GradientTypes from '../../lib/gradient-types';
 import log from '../../log/log';
 
 const colorToBackground = (color, color2, gradientType) => {
-    if (color === MIXED || color2 === MIXED) return 'white';
+    if (color === MIXED || (gradientType !== GradientTypes.SOLID && color2 === MIXED)) return 'white';
     if (color === null) color = 'white';
     if (color2 === null) color2 = 'white';
     switch (gradientType) {


### PR DESCRIPTION
### Resolves

Resolves #1118

### Proposed Changes

This PR changes the "color is mixed" check in `colorToBackground` to match the one in the `ColorButton` component itself.

Previously, `colorToBackground` considered a color state to be "mixed" if `color` was `MIXED` or `color2` was `MIXED`. Now, it considers a color state "mixed" if `color` is `MIXED` or `color2` is `MIXED` *and* the gradient type is non-solid.

### Reason for Changes

If you select a group with "mixed" gradient types, then color and color2 will both be MIXED. If you then select a shape with a solid color, it won't reset color2, which will remain MIXED. We only want the background to appear white if color2 is MIXED *and* the gradient type actually uses color2. This is already done in the component itself, which only shows the "mixed" icon if the gradient type is non-solid, but colorToBackground left out this gradient type check.

### Test Coverage
Tested manually