### PR TITLE
Make generated secondary color always visibly differ from primary color

### DIFF
--- a/src/containers/bit-fill-mode.jsx
+++ b/src/containers/bit-fill-mode.jsx
@@ -13,7 +13,7 @@ import {clearSelectedItems} from '../reducers/selected-items';
 import {changeGradientType} from '../reducers/fill-mode-gradient-type';
 import {clearSelection} from '../helper/selection';
 import FillTool from '../helper/bit-tools/fill-tool';
-import {getRotatedColor, MIXED} from '../helper/style-path';
+import {generateSecondaryColor, MIXED} from '../helper/style-path';
 
 class BitFillMode extends React.Component {
     constructor (props) {
@@ -69,13 +69,13 @@ class BitFillMode extends React.Component {
         let color2 = this.props.color2;
         if (gradientType !== this.props.styleGradientType) {
             if (this.props.styleGradientType === GradientTypes.SOLID) {
-                color2 = getRotatedColor(color);
+                color2 = generateSecondaryColor(color);
                 this.props.onChangeFillColor(color2, 1);
             }
             this.props.changeGradientType(gradientType);
         }
         if (this.props.color2 === MIXED) {
-            color2 = getRotatedColor();
+            color2 = generateSecondaryColor();
             this.props.onChangeFillColor(color2, 1);
         }
         this.tool = new FillTool(this.props.onUpdateImage);

--- a/src/containers/color-indicator.jsx
+++ b/src/containers/color-indicator.jsx
@@ -13,7 +13,7 @@ import ColorIndicatorComponent from '../components/color-indicator.jsx';
 import {applyColorToSelection,
     applyGradientTypeToSelection,
     applyStrokeWidthToSelection,
-    getRotatedColor,
+    generateSecondaryColor,
     swapColorsInSelection,
     MIXED} from '../helper/style-path';
 
@@ -97,7 +97,7 @@ const makeColorIndicator = (label, isStroke) => {
             if (this.props.gradientType === GradientTypes.SOLID && gradientType !== GradientTypes.SOLID) {
                 // Generate color 2 and change to the 2nd swatch when switching from solid to gradient
                 if (!hasSelectedItems) {
-                    this.props.onChangeColor(getRotatedColor(this.props.color), 1);
+                    this.props.onChangeColor(generateSecondaryColor(this.props.color), 1);
                 }
                 this.props.onChangeColorIndex(1);
             }

--- a/src/containers/fill-mode.jsx
+++ b/src/containers/fill-mode.jsx
@@ -5,7 +5,7 @@ import bindAll from 'lodash.bindall';
 import Modes from '../lib/modes';
 import GradientTypes from '../lib/gradient-types';
 import FillTool from '../helper/tools/fill-tool';
-import {getRotatedColor, MIXED} from '../helper/style-path';
+import {generateSecondaryColor, MIXED} from '../helper/style-path';
 
 import {changeFillColor, changeFillColor2, DEFAULT_COLOR} from '../reducers/fill-style';
 import {changeMode} from '../reducers/modes';
@@ -73,13 +73,13 @@ class FillMode extends React.Component {
         let fillColor2 = this.props.fillColor2;
         if (gradientType !== this.props.fillStyleGradientType) {
             if (this.props.fillStyleGradientType === GradientTypes.SOLID) {
-                fillColor2 = getRotatedColor(fillColor);
+                fillColor2 = generateSecondaryColor(fillColor);
                 this.props.onChangeFillColor(fillColor2, 1);
             }
             this.props.changeGradientType(gradientType);
         }
         if (this.props.fillColor2 === MIXED) {
-            fillColor2 = getRotatedColor(fillColor);
+            fillColor2 = generateSecondaryColor(fillColor);
             this.props.onChangeFillColor(fillColor2, 1);
         }
         this.tool = new FillTool(

--- a/src/helper/style-path.js
+++ b/src/helper/style-path.js
@@ -48,7 +48,7 @@ const getColorStringForTransparent = function (colorToMatch) {
 };
 
 // Returns a color shift by 72 of the given color, DEFAULT_COLOR if the given color is null, or null if it is MIXED.
-const getRotatedColor = function (firstColor) {
+const generateSecondaryColor = function (firstColor) {
     if (firstColor === MIXED) return null;
     const color = new paper.Color(firstColor);
     if (!firstColor || color.alpha === 0) return DEFAULT_COLOR;
@@ -262,7 +262,7 @@ const applyGradientTypeToSelection = function (gradientType, applyToStroke, text
         let itemColor2;
         if (!hasGradient || !itemColor.gradient.stops[1]) {
             // If item color is solid or a gradient that has no 2nd color, set the 2nd color based on the first color
-            itemColor2 = getRotatedColor(itemColor1);
+            itemColor2 = generateSecondaryColor(itemColor1);
         } else if (itemColor.gradient.stops[1].color.alpha === 0) {
             // Gradient has 2nd color which is transparent
             itemColor2 = null;
@@ -600,7 +600,7 @@ export {
     applyStrokeWidthToSelection,
     createGradientObject,
     getColorsFromSelection,
-    getRotatedColor,
+    generateSecondaryColor,
     MIXED,
     styleBlob,
     styleShape,


### PR DESCRIPTION
### Resolves

Resolves #1127

### Proposed Changes

This PR changes the way corresponding secondary colors for gradients are chosen:

- If the primary color is bright and saturated, it will return that color, hue-shifted (like it currently does)
- If the primary color is dark and saturated, it will return that color, hue-shifted and brightened
- If the primary color is not very saturated, it will return that color, brightened or darkened (whichever contrasts more)

Note that if the primary color is not saturated, then the secondary color will not be hue-shifted. I did this because a hue shift would be hard to see anyway, and might create confusion, but it may also be confusing to only hue-shift *sometimes*? I'm not really sure.

### Reason for Changes

This should make gradients a lot more obvious when you enable them under certain circumstances (e.g. your primary color is dark or desaturated).

In particular, since the default outline color is black, enabling gradients on outlines would otherwise be very non-obvious/confusing.

### Test Coverage

Tested manually