### PR TITLE
Keyboard shortcuts added

### DIFF
--- a/src/hocs/keyboard-shortcuts-hoc.jsx
+++ b/src/hocs/keyboard-shortcuts-hoc.jsx
@@ -8,7 +8,7 @@ import CopyPasteHOC from './copy-paste-hoc.jsx';
 
 import {selectAllBitmap} from '../helper/bitmap';
 import {clearSelection, deleteSelection, getSelectedLeafItems,
-    selectAllItems, selectAllSegments} from '../helper/selection';
+    selectAllItems, selectAllSegments, getSelectedRootItems} from '../helper/selection';
 import {groupSelection, shouldShowGroup, ungroupSelection, shouldShowUngroup} from '../helper/group';
 import {clearSelectedItems, setSelectedItems} from '../reducers/selected-items';
 import {changeMode} from '../reducers/modes';
@@ -64,9 +64,12 @@ const KeyboardShortcutsHOC = function (WrappedComponent) {
                     this.changeToASelectMode();
                     this.props.onPasteFromClipboard();
                 } else if (event.key === 'x') {
-                    this.props.onCopyToClipboard();
-                    if (deleteSelection(this.props.mode, this.props.onUpdateImage)) {
-                        this.props.setSelectedItems(this.props.format);
+                    const selectedItems = getSelectedRootItems();
+                    if (selectedItems.length > 0) {
+                        this.props.onCopyToClipboard();
+                        if (deleteSelection(this.props.mode, this.props.onUpdateImage)) {
+                            this.props.setSelectedItems(this.props.format);
+                        }
                     }
                     event.preventDefault();
                 } else if (event.key === 'a') {

--- a/src/hocs/keyboard-shortcuts-hoc.jsx
+++ b/src/hocs/keyboard-shortcuts-hoc.jsx
@@ -9,6 +9,7 @@ import CopyPasteHOC from './copy-paste-hoc.jsx';
 import {selectAllBitmap} from '../helper/bitmap';
 import {clearSelection, deleteSelection, getSelectedLeafItems,
     selectAllItems, selectAllSegments} from '../helper/selection';
+import {groupSelection, ungroupSelection} from '../helper/group';
 import {clearSelectedItems, setSelectedItems} from '../reducers/selected-items';
 import {changeMode} from '../reducers/modes';
 
@@ -47,11 +48,23 @@ const KeyboardShortcutsHOC = function (WrappedComponent) {
                     this.props.onRedo();
                 } else if (event.key === 'z') {
                     this.props.onUndo();
+                } else if (event.shiftKey && event.key.toLowerCase() === 'g') {
+                    ungroupSelection(clearSelectedItems, setSelectedItems, this.props.onUpdateImage);
+                    event.preventDefault();
+                } else if (event.key === 'g') {
+                    groupSelection(clearSelectedItems, setSelectedItems, this.props.onUpdateImage);
+                    event.preventDefault();
                 } else if (event.key === 'c') {
                     this.props.onCopyToClipboard();
                 } else if (event.key === 'v') {
                     this.changeToASelectMode();
                     this.props.onPasteFromClipboard();
+                } else if (event.key === 'x') {
+                    this.props.onCopyToClipboard();
+                    if (deleteSelection(this.props.mode, this.props.onUpdateImage)) {
+                        this.props.setSelectedItems(this.props.format);
+                    }
+                    event.preventDefault();
                 } else if (event.key === 'a') {
                     this.changeToASelectMode();
                     event.preventDefault();

--- a/src/hocs/keyboard-shortcuts-hoc.jsx
+++ b/src/hocs/keyboard-shortcuts-hoc.jsx
@@ -9,7 +9,7 @@ import CopyPasteHOC from './copy-paste-hoc.jsx';
 import {selectAllBitmap} from '../helper/bitmap';
 import {clearSelection, deleteSelection, getSelectedLeafItems,
     selectAllItems, selectAllSegments} from '../helper/selection';
-import {groupSelection, ungroupSelection} from '../helper/group';
+import {groupSelection, shouldShowGroup, ungroupSelection, shouldShowUngroup} from '../helper/group';
 import {clearSelectedItems, setSelectedItems} from '../reducers/selected-items';
 import {changeMode} from '../reducers/modes';
 
@@ -49,10 +49,14 @@ const KeyboardShortcutsHOC = function (WrappedComponent) {
                 } else if (event.key === 'z') {
                     this.props.onUndo();
                 } else if (event.shiftKey && event.key.toLowerCase() === 'g') {
-                    ungroupSelection(clearSelectedItems, setSelectedItems, this.props.onUpdateImage);
+                    if (shouldShowUngroup()) {
+                        ungroupSelection(clearSelectedItems, setSelectedItems, this.props.onUpdateImage);
+                    }
                     event.preventDefault();
                 } else if (event.key === 'g') {
-                    groupSelection(clearSelectedItems, setSelectedItems, this.props.onUpdateImage);
+                    if (shouldShowGroup()) {
+                        groupSelection(clearSelectedItems, setSelectedItems, this.props.onUpdateImage);
+                    }
                     event.preventDefault();
                 } else if (event.key === 'c') {
                     this.props.onCopyToClipboard();


### PR DESCRIPTION
### Resolves

#711 

### Proposed Changes

Added 3 keyboard shortcuts

CMD + G calls groupSelection if shouldShowGroup equals true and prevents default
SHIFT + CMD + G calls ungroupSelection  if shouldShowUngroup equals true and prevents default
CMD + X calls onCopyToClipboard followed by deleteSelection if getSelectedRootItems has items

Remark: this introduces a little assymetry between copy and cut, because if nothing is selected copy will copy all. I have tried same approach with cut but that seems unintuitive.

### Reason for Changes

Missing shortcuts

### Test Coverage

Manually tested