### PR TITLE
#1150 Hor/ver line scaling

### DIFF
--- a/src/helper/selection-tools/bounding-box-tool.js
+++ b/src/helper/selection-tools/bounding-box-tool.js
@@ -211,6 +211,7 @@ class BoundingBoxTool {
             this.boundsRect.curves[2].divideAtTime(0.5);
             this.boundsRect.curves[4].divideAtTime(0.5);
             this.boundsRect.curves[6].divideAtTime(0.5);
+            this.boundsPath.selectionRect = this.boundsRect;
             this.boundsPath.addChild(this.boundsRect);
 
             const vRect = new paper.Path.Rectangle({
@@ -298,7 +299,8 @@ class BoundingBoxTool {
                 rotHandle.parent = getGuideLayer();
                 this.boundsRotHandles[index] = rotHandle;
             }
-
+            if (rect.height < 1e-8 && index !== 1 && index !== 5) continue;
+            if (rect.width < 1e-8 && index !== 3 && index !== 7) continue;
             this.boundsScaleHandles[index] = boundsScaleHandle.clone();
             this.boundsScaleHandles[index].position = segment.point;
             for (const child of this.boundsScaleHandles[index].children) {

--- a/src/helper/selection-tools/scale-tool.js
+++ b/src/helper/selection-tools/scale-tool.js
@@ -40,12 +40,13 @@ class ScaleTool {
         this.active = true;
 
         const index = hitResult.item.data.index;
-        this.pivot = boundsPath.bounds[this._getOpposingRectCornerNameByIndex(index)].clone();
-        this.origPivot = boundsPath.bounds[this._getOpposingRectCornerNameByIndex(index)].clone();
-        this.corner = boundsPath.bounds[this._getRectCornerNameByIndex(index)].clone();
+        const bounds = boundsPath.selectionRect.bounds;
+        this.pivot = bounds[this._getOpposingRectCornerNameByIndex(index)].clone();
+        this.origPivot = bounds[this._getOpposingRectCornerNameByIndex(index)].clone();
+        this.corner = bounds[this._getRectCornerNameByIndex(index)].clone();
         this.selectionAnchor = boundsPath.selectionAnchor;
         this.origSize = this.corner.subtract(this.pivot);
-        this.origCenter = boundsPath.bounds.center;
+        this.origCenter = bounds.center;
         this.isCorner = this._isCorner(index);
         this.centered = false;
         this.lastSx = 1;


### PR DESCRIPTION
### Resolves

Fixes #1150 

### Proposed Changes

Do not show scaling anchors when the anchor would scale a zero sized side.

This means for
- zero height () bounds only show left-middle and right-middle handles
- zero width () bounds only show top-middel and bottom-middle handles

Also I corrected the use of boundsPath.bounds ScaleTool. boundsPath was including the selectionAnchor as a child, so the size of the anchor (24) was also used in the calculations. I fixed this by adding selectionRect separate of selectionAnchor to the boundsPath.

(I used 1e-8 as zero bound because I saw one case of a vertical line where width of bounds was 1e-14)

### Reason for Changes

To fix issue

### Test Coverage

Manually tested