### PR TITLE
Make slider handles stick to the cursor

### DIFF
--- a/src/components/color-picker/color-picker.jsx
+++ b/src/components/color-picker/color-picker.jsx
@@ -5,7 +5,7 @@ import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-int
 import classNames from 'classnames';
 import parseColor from 'parse-color';
 
-import Slider from '../forms/slider.jsx';
+import Slider, {CONTAINER_WIDTH, HANDLE_WIDTH} from '../forms/slider.jsx';
 import LabeledIconButton from '../labeled-icon-button/labeled-icon-button.jsx';
 import styles from './color-picker.css';
 import GradientTypes from '../../lib/gradient-types';
@@ -53,6 +53,16 @@ class ColorPickerComponent extends React.Component {
                 throw new Error(`Unknown channel for color sliders: ${channel}`);
             }
         }
+
+        // The sliders are a rounded capsule shape, and the slider handles are circles. As a consequence, when the
+        // slider handle is fully to one side, its center is actually moved away from the start/end of the slider by
+        // the slider handle's radius, meaning that the effective range of the slider excludes the rounded caps.
+        // To compensate for this, position the first stop to where the rounded cap ends, and position the last stop
+        // to where the rounded cap begins.
+        const halfHandleWidth = HANDLE_WIDTH / 2;
+        stops[0] += ` 0 ${halfHandleWidth}px`;
+        stops[stops.length - 1] += ` ${CONTAINER_WIDTH - halfHandleWidth}px 100%`;
+
         return `linear-gradient(to left, ${stops.join(',')})`;
     }
     render () {

--- a/src/components/forms/slider.jsx
+++ b/src/components/forms/slider.jsx
@@ -115,3 +115,4 @@ SliderComponent.defaultProps = {
 };
 
 export default SliderComponent;
+export {CONTAINER_WIDTH, HANDLE_WIDTH};

--- a/src/components/forms/slider.jsx
+++ b/src/components/forms/slider.jsx
@@ -47,6 +47,9 @@ class SliderComponent extends React.Component {
     }
 
     handleClickBackground (event) {
+        // Because the slider handle is a child of the "background" element this handler is registered to, it calls this
+        // when clicked as well. We only want to change the slider value if the user clicked on the background itself.
+        if (event.target !== this.background) return;
         // Move slider handle's center to the cursor
         this.handleClickOffset = HANDLE_WIDTH / 2;
         this.props.onChange(this.scaleMouseToSliderPosition(event));

--- a/src/components/forms/slider.jsx
+++ b/src/components/forms/slider.jsx
@@ -17,15 +17,21 @@ class SliderComponent extends React.Component {
             'handleMouseUp',
             'handleMouseMove',
             'handleClickBackground',
-            'setBackground'
+            'setBackground',
+            'setHandle'
         ]);
+
+        // Distance from the left edge of the slider handle to the mouse down/click event
+        this.handleClickOffset = 0;
     }
 
-    handleMouseDown () {
+    handleMouseDown (event) {
         document.addEventListener('mousemove', this.handleMouseMove);
         document.addEventListener('mouseup', this.handleMouseUp);
         document.addEventListener('touchmove', this.handleMouseMove, {passive: false});
         document.addEventListener('touchend', this.handleMouseUp);
+
+        this.handleClickOffset = getEventXY(event).x - this.handle.getBoundingClientRect().left;
     }
 
     handleMouseUp () {
@@ -41,18 +47,24 @@ class SliderComponent extends React.Component {
     }
 
     handleClickBackground (event) {
+        // Move slider handle's center to the cursor
+        this.handleClickOffset = HANDLE_WIDTH / 2;
         this.props.onChange(this.scaleMouseToSliderPosition(event));
     }
 
     scaleMouseToSliderPosition (event){
         const {x} = getEventXY(event);
         const backgroundBBox = this.background.getBoundingClientRect();
-        const scaledX = x - backgroundBBox.left;
-        return Math.max(0, Math.min(100, 100 * scaledX / backgroundBBox.width));
+        const scaledX = x - backgroundBBox.left - this.handleClickOffset;
+        return Math.max(0, Math.min(100, 100 * scaledX / (backgroundBBox.width - HANDLE_WIDTH)));
     }
 
     setBackground (ref) {
         this.background = ref;
+    }
+
+    setHandle (ref) {
+        this.handle = ref;
     }
 
     render () {
@@ -76,6 +88,7 @@ class SliderComponent extends React.Component {
             >
                 <div
                     className={styles.handle}
+                    ref={this.setHandle}
                     style={{
                         left: `${handleOffset}px`
                     }}


### PR DESCRIPTION
### Resolves

Resolves #1202

### Proposed Changes

This PR adjusts the color slider position calculation to take into account where the user first clicked on the handle.

### Reason for Changes

This prevents sliders from "jumping" when the user starts dragging them:

Before | After
--- | ---
![Peek 2020-07-31 12-26](https://user-images.githubusercontent.com/25993062/89056328-d93d1400-d329-11ea-8d0d-df73fbbf15ef.gif) | ![Peek 2020-07-31 12-32](https://user-images.githubusercontent.com/25993062/89056383-ee19a780-d329-11ea-910d-b384416f9493.gif)


### Test Coverage

Tested manually.