### PR TITLE
Add scratch render fonts as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "react-responsive": "^4",
     "react-style-proptype": "^3",
     "react-tooltip": "^3",
-    "redux": "^3"
+    "redux": "^3",
+    "scratch-render-fonts": "^0.2.0"
   },
   "devDependencies": {
     "autoprefixer": "9.7.4",


### PR DESCRIPTION
### Resolves
This dep should have been in scratch paint's peer dependencies, because although paint works fine without it, the fonts would not render when using the text tool without this peer dependency

Currently scratch-render-fonts comes in through scratch-svg-renderer, but this will change with https://github.com/LLK/scratch-paint/pull/1280