### PR TITLE
Use fixupSVGString from scratch-svg-renderer

### DIFF
--- a/src/containers/paint-editor.jsx
+++ b/src/containers/paint-editor.jsx
@@ -310,6 +310,7 @@ class PaintEditor extends React.Component {
                 canUndo={this.props.shouldShowUndo}
                 canvas={this.state.canvas}
                 colorInfo={this.state.colorInfo}
+                fixupSvgStringFn={this.props.fixupSvgStringFn}
                 format={this.props.format}
                 image={this.props.image}
                 imageFormat={this.props.imageFormat}
@@ -341,6 +342,7 @@ PaintEditor.propTypes = {
     changeColorToEyeDropper: PropTypes.func,
     changeMode: PropTypes.func.isRequired,
     clearSelectedItems: PropTypes.func.isRequired,
+    fixupSvgStringFn: PropTypes.func,
     format: PropTypes.oneOf(Object.keys(Formats)), // Internal, up-to-date data format
     fontInlineFn: PropTypes.func,
     handleSwitchToBitmap: PropTypes.func.isRequired,

--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -195,16 +195,11 @@ class PaperCanvas extends React.Component {
     }
     importSvg (svg, rotationCenterX, rotationCenterY) {
         const paperCanvas = this;
-        // Pre-process SVG to prevent parsing errors (discussion from #213)
-        // 1. Remove svg: namespace on elements.
-        // TODO: remove
-        svg = svg.split(/<\s*svg:/).join('<');
-        svg = svg.split(/<\/\s*svg:/).join('</');
-        // 2. Add root svg namespace if it does not exist.
-        const svgAttrs = svg.match(/<svg [^>]*>/);
-        if (svgAttrs && svgAttrs[0].indexOf('xmlns=') === -1) {
-            svg = svg.replace(
-                '<svg ', '<svg xmlns="http://www.w3.org/2000/svg" ');
+        if (this.props.fixupSvgStringFn) {
+            // Pre-process SVG to prevent parsing errors (discussion from #213)
+            svg = this.props.fixupSvgStringFn(svg);
+        } else {
+            log.error('Some SVGs may crash the paint editor if fixupSvgStringFn prop is not set on PaintEditor.');
         }
 
         // Get the origin which the viewBox is defined relative to. During import, Paper will translate
@@ -354,6 +349,7 @@ PaperCanvas.propTypes = {
     clearSelectedItems: PropTypes.func.isRequired,
     clearUndo: PropTypes.func.isRequired,
     cursor: PropTypes.string,
+    fixupSvgStringFn: PropTypes.func,
     format: PropTypes.oneOf(Object.keys(Formats)),
     image: PropTypes.oneOfType([
         PropTypes.string,


### PR DESCRIPTION
## Depends on https://github.com/LLK/scratch-svg-renderer/pull/209, https://github.com/LLK/scratch-svg-renderer/pull/210, and https://github.com/LLK/scratch-gui/pull/6556

### Resolves

Resolves #1269

### Proposed Changes

This PR changes the `importSVG` function to use the `fixupSvgString` function from `scratch-svg-renderer` instead of applying its own fixes to the imported SVG string.

### Reason for Changes

See the rationale in #210. This should result in all renderable SVGs also being editable in the paint editor--no more SVGs that render but crash the paint editor. Now, either an SVG is parseable or it'll be replaced with the grey question mark asset everywhere.

### Test Coverage

Tested manually