### PR TITLE
Circle ci setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 aliases:
   - &defaults
       docker:
-        - image: cimg/node:12-browsers
+        - image: cimg/node:12.22.11-browsers
       working_directory: ~/repo
       environment:
         NODE_ENV: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ aliases:
   - &defaults
       docker:
         - image: cimg/node:12.22.11-browsers
+          auth:
+            username: $DOCKERHUB_USERNAME
+            password: $DOCKERHUB_PASSWORD
       working_directory: ~/repo
       environment:
         NODE_ENV: production
@@ -41,9 +44,11 @@ workflows:
   build-test-no-deploy:
     jobs:
       - build-test:
-        filters:
-          branches:
-            ignore:
-              - master
-              - develop
-              - /^hotfix\/.*/
+          context:
+            - dockerhub-credentials
+          filters:
+            branches:
+                ignore:
+                  - master
+                  - develop
+                  - /^hotfix\/.*/


### PR DESCRIPTION
### Resolves

The CircleCI build fails

### Proposed Changes

Uses the correct docker image for CircleCI
Sets up our dockerhub credentials with a context in CircleCI

### Reason for Changes

The build currently fails because we were attempting to use an invalid docker image.
It also will get rid of a warning that we aren't using our own dockerhub credentials.

### Test Coverage

Lint and unit tests pass.