### PR TITLE
Add gh-pages deploy to circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ aliases:
       working_directory: ~/repo
       environment:
         NODE_ENV: production
-        RELEASE_TIMESTAMP: "$(date +'%Y%m%d%H%M%S')"
   - &setup
     name: "setup"
     command: |
@@ -25,6 +24,23 @@ aliases:
     name: "run npm build"
     command: |
       NODE_ENV=production npm run build
+  - &tag-setup
+    name: "setup tags"
+    command: |
+      RELEASE_TIMESTAMP="$(date +'%Y%m%d%H%M%S')"
+      VPKG=$($(npm bin)/json -f package.json version)
+      export RELEASE_VERSION=${VPKG}-prerelease.${RELEASE_TIMESTAMP}
+      echo $RELEASE_VERSION
+      export NPM_TAG=latest
+      if [[ "$CIRCLE_BRANCH" == hotfix/* ]]; then # double brackets are important for matching the wildcard
+        export NPM_TAG=hotfix
+      fi
+  - &deploy-gh-pages
+    name: "deploy to gh pages"
+    command: |
+      git config --global user.email $(git log --pretty=format:"%ae" -n1)
+      git config --global user.name $(git log --pretty=format:"%an" -n1)
+      npm run deploy -- -e $CIRCLE_BRANCH
 
 jobs:
   build-test:


### PR DESCRIPTION
### Proposed Changes

In CircleCI, Adds a build-test-deploy workflow for develop, master, and hotfix branches
Adds a deploy to gh-pages step to the build-test-deploy workflow

### Reason for Changes

So we can deploy scratch-paint to gh-pages using CircleCI
