### PR TITLE
circleci ignores gh-pages branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ workflows:
                   - master
                   - develop
                   - /^hotfix\/.*/
+                  - gh-pages
   build-test-deploy:
     jobs:
       - build-test-deploy:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run clean && webpack --progress --colors --bail",
     "clean": "rimraf ./dist && mkdirp dist && rimraf ./playground && mkdirp playground",
-    "deploy": "touch playground/.nojekyll && gh-pages -t -d playground -m \"Build for $(git log --pretty=format:%H -n1)\"",
+    "deploy": "touch playground/.nojekyll && gh-pages -t -d playground -m \"[skip ci] Build for $(git log --pretty=format:%H -n1)\"",
     "i18n:push": "tx-push-src scratch-editor paint-editor ./translations/en.json",
     "i18n:src": "rimraf ./translations/messages && babel src > tmp.js && rimraf tmp.js && ./scripts/build-i18n-source.js ./translations/messages/ ./translations/",
     "lint": "eslint . --ext .js,.jsx",


### PR DESCRIPTION
### Resolves

pushing to gh-pages kicks off another build-test workflow, which happens every time we deploy

### Proposed Changes

adds the gh-pages branch to the list of branches to be ignored in the circleci config

### Reason for Changes

Will make it so we don't kick off an extra build-test workflow after we deploy
