### PR TITLE
Hotfix/circleci deploy npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,13 +29,11 @@ aliases:
     command: |
       RELEASE_TIMESTAMP="$(date +'%Y%m%d%H%M%S')"
       VPKG=$($(npm bin)/json -f package.json version)
-      export RELEASE_VERSION=${VPKG}-prerelease.${RELEASE_TIMESTAMP}
-      echo $RELEASE_VERSION
+      echo export RELEASE_VERSION=${VPKG}-prerelease.${RELEASE_TIMESTAMP} >> $BASH_ENV
       echo export NPM_TAG=latest >> $BASH_ENV
       if [[ "$CIRCLE_BRANCH" == hotfix/* ]]; then # double brackets are important for matching the wildcard
         echo export NPM_TAG=hotfix >> $BASH_ENV
       fi
-      npm version --no-git-tag-version $RELEASE_VERSION
   - &deploy-gh-pages
     name: "deploy to gh pages"
     command: |
@@ -45,9 +43,17 @@ aliases:
   - &deploy-npm
     name: "deploy to npm"
     command: |
-      echo $NPM_TAG
+      echo "npm tag: $NPM_TAG"
+      echo "release version: $RELEASE_VERSION"
+      npm version --no-git-tag-version $RELEASE_VERSION
       npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
       npm publish --tag $NPM_TAG
+  - &tag-commit
+    name: "tag commit in github"
+    command: |
+      echo $RELEASE_VERSION
+      git tag $RELEASE_VERSION
+      git push $CIRCLE_REPOSITORY_URL $RELEASE_VERSION
 
 jobs:
   build-test:
@@ -84,6 +90,8 @@ jobs:
           <<: *deploy-gh-pages
       - run:
           <<: *deploy-npm
+      - run:
+          <<: *tag-commit
 
 workflows:
   build-test-no-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,16 +31,23 @@ aliases:
       VPKG=$($(npm bin)/json -f package.json version)
       export RELEASE_VERSION=${VPKG}-prerelease.${RELEASE_TIMESTAMP}
       echo $RELEASE_VERSION
-      export NPM_TAG=latest
+      echo export NPM_TAG=latest >> $BASH_ENV
       if [[ "$CIRCLE_BRANCH" == hotfix/* ]]; then # double brackets are important for matching the wildcard
-        export NPM_TAG=hotfix
+        echo export NPM_TAG=hotfix >> $BASH_ENV
       fi
+      npm version --no-git-tag-version $RELEASE_VERSION
   - &deploy-gh-pages
     name: "deploy to gh pages"
     command: |
       git config --global user.email $(git log --pretty=format:"%ae" -n1)
       git config --global user.name $(git log --pretty=format:"%an" -n1)
       npm run deploy -- -e $CIRCLE_BRANCH
+  - &deploy-npm
+    name: "deploy to npm"
+    command: |
+      echo $NPM_TAG
+      npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+      npm publish --tag $NPM_TAG
 
 jobs:
   build-test:
@@ -75,6 +82,8 @@ jobs:
           <<: *tag-setup
       - run:
           <<: *deploy-gh-pages
+      - run:
+          <<: *deploy-npm
 
 workflows:
   build-test-no-deploy:


### PR DESCRIPTION
### Proposed Changes

circleci can now deploy to npm and push the release tag to github as part of the deploy

### Reason for Changes

To move completely from travis to circleci we need to deploy to npm.  Part of that deploy is to tag the correct commit with the release version in github
