### PR TITLE
Fix: Color unalterable using brush and line tools

### DIFF
--- a/src/helper/bitmap.js
+++ b/src/helper/bitmap.js
@@ -208,7 +208,7 @@ const getBrushMark = function (size, color, isEraser) {
     canvas.height = roundedUpRadius * 2;
     const context = canvas.getContext('2d');
     context.imageSmoothingEnabled = false;
-    context.fillStyle = isEraser ? 'white' : color;
+    context.fillStyle = isEraser ? 'white' : color.toCSS(true);
     // Small squares for pixel artists
     if (size <= 5) {
         let offset = 0;


### PR DESCRIPTION
### Resolves

- No known Github Issue

### Proposed Changes

Set brush mask's fillStyle to a hex string.

### Reason for Changes

The BrushTool and LineTool's setColor function both have an incoming parameter `color`, and it is used to set the fillStyle of the canvas in the getBrushMark function. However in develop branch, the `color` is a CSS color string, which has changed to `paper.Color` in this branch, causing the color cannot be set properly.

### Test Coverage

I tested it on my machine, both in the playground and sc-gui.