### PR TITLE
ci: do not run commitlint on develop branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 aliases:
   - &defaults
       docker:
-        - image: cimg/node:lts-browsers
+        - image: cimg/node:16.18.1-browsers
           auth:
             username: $DOCKERHUB_USERNAME
             password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,12 @@ workflows:
     jobs:
       - commitlint/lint:
           target-branch: develop
+          filters:
+            branches:
+                ignore:
+                  - master
+                  - develop
+                  - /^hotfix\/.*/
   build-test-no-deploy:
     jobs:
       - build-test:


### PR DESCRIPTION
### Resolves

- Resolves [ENA-199](https://scratchfoundation.atlassian.net/browse/ENA-199)

### Proposed Changes

- Skip `commitlint` on the following branches:
  - `master`
  - `develop`
  - `hotfix/*`
- Use Node 16 since LTS is failing due to ENA-195

### Reason for Changes

We do not want to re-write commit history on these "main" branches. Commit messages that do not follow conventional commit should be caught in other branches. However, this way the CI won't fail if they are merged to one of these branches. 

### Test Coverage

- Ran `circleci config validate` to validate the configuration

[ENA-199]: https://scratchfoundation.atlassian.net/browse/ENA-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ