### PR TITLE
fix: svg viewbox match wrong

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -213,7 +213,7 @@ class PaperCanvas extends React.Component {
         const parser = new DOMParser();
         const svgDom = parser.parseFromString(svg, 'text/xml');
         const viewBox = svgDom.documentElement.attributes.viewBox ?
-            svgDom.documentElement.attributes.viewBox.value.match(/\S+/g) : null;
+            svgDom.documentElement.attributes.viewBox.value.match(/-?\d+(\.\d+)?/g) : null;
         if (viewBox) {
             for (let i = 0; i < viewBox.length; i++) {
                 viewBox[i] = parseFloat(viewBox[i]);


### PR DESCRIPTION
Fixed a matching error when the viewbox value of SVG is not separated by spaces.

### Resolves

https://github.com/scratchfoundation/scratch-paint/issues/2245

### Proposed Changes

fixed https://github.com/scratchfoundation/scratch-paint/issues/2245

### Reason for Changes

see https://github.com/scratchfoundation/scratch-paint/issues/2245

### Test Coverage
Manual testing