### PR TITLE
fix(deps): Use terser-webpack-plugin instead of uglifyjs-webpack-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "style-loader": "1.3.0",
         "svg-url-loader": "3.0.3",
         "tap": "14.11.0",
-        "uglifyjs-webpack-plugin": "2.2.0",
+        "terser-webpack-plugin": "1.4.5",
         "url-loader": "2.3.0",
         "webpack": "4.46.0",
         "webpack-cli": "3.3.12",
@@ -26145,12 +26145,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
-    "node_modules/serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
-      "dev": true
-    },
     "node_modules/serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
@@ -30246,86 +30240,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
       "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
       "dev": true
-    },
-    "node_modules/uglifyjs-webpack-plugin": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz",
-      "integrity": "sha512-mHSkufBmBuJ+KHQhv5H0MXijtsoA1lynJt1lXOaotja8/I0pR4L9oGaPIZw+bQBOFittXZg9OC1sXSGO9D9ZYg==",
-      "dev": true,
-      "dependencies": {
-        "cacache": "^12.0.2",
-        "find-cache-dir": "^2.1.0",
-        "is-wsl": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.6.0",
-        "webpack-sources": "^1.4.0",
-        "worker-farm": "^1.7.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0"
-      }
-    },
-    "node_modules/uglifyjs-webpack-plugin/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/uglifyjs-webpack-plugin/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/uglifyjs-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
-    "node_modules/uglifyjs-webpack-plugin/node_modules/schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/uglifyjs-webpack-plugin/node_modules/uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "dev": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "style-loader": "1.3.0",
     "svg-url-loader": "3.0.3",
     "tap": "14.11.0",
-    "uglifyjs-webpack-plugin": "2.2.0",
+    "terser-webpack-plugin": "1.4.5",
     "url-loader": "2.3.0",
     "webpack": "4.46.0",
     "webpack-cli": "3.3.12",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 // Plugins
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 // PostCss
 const autoprefixer = require('autoprefixer');
@@ -64,7 +64,7 @@ const base = {
     },
     optimization: {
         minimizer: [
-            new UglifyJsPlugin({
+            new TerserPlugin({
                 include: /\.min\.js$/
             })
         ]


### PR DESCRIPTION
### Proposed Changes

This PR does three things:

* Mark `terser-webpack-plugin@1.4.5` (an existing dependency, via webpack) as a saved dev dependency.
* Remove dev dependency `uglifyjs-webpack-plugin`.
* Replace `UglifyJsPlugin` with `TerserPlugin` in Webpack config.

### Reason for Changes

[`uglifyjs-webpack-plugin` is deprecated.](https://github.com/webpack-contrib/uglifyjs-webpack-plugin#readme) The docs indicate to use [`terser-webpack-plugin`](https://webpack.js.org/plugins/terser-webpack-plugin/) instead.

The version `terser-webpack-plugin@1.4.5` is selected as it's the version which was previously installed (as a dependency of `webpack@4.46.0`, matching `^1.4.3`). This means we don't actually add or update any dependencies: note how `package-lock.json` changes only include removing dependencies.

Marking `terser-webpack-plugin` as saved at all [is required](https://webpack.js.org/plugins/terser-webpack-plugin/):

> Webpack v5 comes with the latest `terser-webpack-plugin` out of the box. If you are using Webpack v5 or above and wish to customize the options, you will still need to install `terser-webpack-plugin`. Using Webpack v4, you have to install `terser-webpack-plugin` v4.

**Removing uglifyjs-webpack-plugin is necessary to update to Webpack v5.** uglifyjs-webpack-plugin has not been updated since 2019 and strictly requires Webpack v4. Terser is the replacement Webpack recommends, and is supported on both v4 and v5.

Webpack v4 itself is deprecated as well, and due to a compatibility change, prevents readily running on Node above 16. Node 16 left maintenance LTS support in October 2023, so the development environment is now depending on a wholly unsupported version of Node, partially due to Webpack (and consequently `uglifyjs-webpack-plugin`).

### Test Coverage

All existing tests pass, the build succeeds, and `npm start` is also functioning as normal.
