### PR TITLE
chore(deps): update dependency react-tooltip to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "react-responsive": "5.0.0",
         "react-style-proptype": "3.2.2",
         "react-test-renderer": "16.14.0",
-        "react-tooltip": "3.8.4",
+        "react-tooltip": "4.5.1",
         "redux": "3.7.2",
         "redux-mock-store": "1.5.4",
         "redux-throttle": "0.1.1",
@@ -89,7 +89,7 @@
         "react-redux": "^5",
         "react-responsive": "^5",
         "react-style-proptype": "^3",
-        "react-tooltip": "^3",
+        "react-tooltip": "^4",
         "redux": "^3",
         "scratch-render-fonts": "^1.0.0"
       }
@@ -23955,21 +23955,29 @@
       }
     },
     "node_modules/react-tooltip": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.8.4.tgz",
-      "integrity": "sha512-i9rP5eihRNXFqYtyw58fhy+oT7OAEox/WC7XJOSED57s31nLU+uOJai5TgADbwNzJ7xamPkijYF36IfrUGJgcQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.5.1.tgz",
+      "integrity": "sha512-Zo+CSFUGXar1uV+bgXFFDe7VeS2iByeIp5rTgTcc2HqtuOS5D76QapejNNfx320MCY91TlhTQat36KGFTqgcvw==",
       "dev": true,
       "dependencies": {
-        "classnames": "^2.2.5",
-        "prop-types": "^15.6.0",
-        "sanitize-html-react": "^1.13.0"
+        "prop-types": "^15.8.1",
+        "uuid": "^7.0.3"
       },
       "engines": {
-        "node": ">=4.2.1"
+        "npm": ">=6.13"
       },
       "peerDependencies": {
-        "react": ">=0.14",
-        "react-dom": ">=0.14"
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/react-tooltip/node_modules/uuid": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/read-cache": {
@@ -24268,15 +24276,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/regexp-quote": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz",
-      "integrity": "sha512-R9elSUXyJeACXh7raO50vvfZyTdQ1bxYm0KlN2XD8eEzPAnedJTHMk4F7lCaggu9DrfUWP3CDUjAgyW1f2DpgA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -24900,93 +24899,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
-    },
-    "node_modules/sanitize-html-react": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html-react/-/sanitize-html-react-1.13.0.tgz",
-      "integrity": "sha512-EDoOqPd2wrJEV6px8XvWEx7b+JNIoka3mI4fdBVa6S/de9b+UnmzKsVqBkj93s+FwIaBv1fBuXiXkoVxmAU3MQ==",
-      "dev": true,
-      "dependencies": {
-        "htmlparser2": "^3.9.0",
-        "regexp-quote": "0.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "node_modules/sanitize-html-react/node_modules/dom-serializer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/sanitize-html-react/node_modules/dom-serializer/node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ]
-    },
-    "node_modules/sanitize-html-react/node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html-react/node_modules/domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
-    },
-    "node_modules/sanitize-html-react/node_modules/domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/sanitize-html-react/node_modules/domutils": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-      "dev": true,
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/sanitize-html-react/node_modules/entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
-    },
-    "node_modules/sanitize-html-react/node_modules/htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
     },
     "node_modules/saxes": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-redux": "^5",
     "react-responsive": "^5",
     "react-style-proptype": "^3",
-    "react-tooltip": "^3",
+    "react-tooltip": "^4",
     "redux": "^3",
     "scratch-render-fonts": "^1.0.0"
   },
@@ -88,7 +88,7 @@
     "react-responsive": "5.0.0",
     "react-style-proptype": "3.2.2",
     "react-test-renderer": "16.14.0",
-    "react-tooltip": "3.8.4",
+    "react-tooltip": "4.5.1",
     "redux": "3.7.2",
     "redux-mock-store": "1.5.4",
     "redux-throttle": "0.1.1",


### PR DESCRIPTION
### Proposed Changes

Upgrade `react-tooltip` to v4

### Reason for Changes

Resolves this error in more recent versions of `npm`:

```
npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name ">=^16.0.0" of package "react@>=^16.0.0": Tags may not have any characters that encodeURIComponent encodes.
```

### Test Coverage

Test coverage unchanged