### PR TITLE
change README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 #### Scratch-paint provides a paint editor React component that takes and outputs SVGs or PNGs. It can convert between vector and bitmap modes.
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/LLK/scratch-paint.svg)](https://greenkeeper.io/)
-- Try it out at [https://llk.github.io/scratch-paint/](https://llk.github.io/scratch-paint/)
+- Try it out at [https://scratchfoundation.github.io/scratch-paint/](https://scratchfoundation.github.io/scratch-paint/)
 
 - Or, to try it out as part of Scratch 3.0, visit [https://scratch.mit.edu/create](https://scratch.mit.edu/create) and click on the "Costumes" tab.
 


### PR DESCRIPTION
### Resolves

Fixes https://github.com/scratchfoundation/scratch-paint/issues/2927
### Proposed Changes

Change README link to the actual link

### Reason for Changes

so that people can actually use the github-hosted version without changing the url

### Test Coverage

tests not needed