### PR TITLE
fix: strip data-paper-data attributes whose value isn't valid JSON

### DIFF
--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -7,6 +7,7 @@ import {sanitizeSvg} from '@scratch/scratch-svg-renderer';
 import Formats from '../lib/format';
 import log from '../log/log';
 
+import {stripInvalidPaperData} from '../helper/strip-invalid-paper-data';
 import {performSnapshot} from '../helper/undo';
 import {undoSnapshot, clearUndoState} from '../reducers/undo';
 import {isGroup, ungroupItems} from '../helper/group';
@@ -214,6 +215,12 @@ class PaperCanvas extends React.Component {
         // and similar. Run after the namespace fixups so DOMPurify sees a
         // well-formed document.
         svg = sanitizeSvg.sanitizeSvgText(svg);
+
+        // 4. Drop data-paper-data attributes carrying values that aren't valid
+        // JSON. Paper.js calls JSON.parse on this attribute during importSVG
+        // and synchronously throws on malformed values; one bad attribute on
+        // an unrelated element is enough to abort the whole import.
+        svg = stripInvalidPaperData(svg);
 
         // Get the origin which the viewBox is defined relative to. During import, Paper will translate
         // the viewBox to start at (0, 0), and we need to translate it back for some costumes to render

--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -216,17 +216,12 @@ class PaperCanvas extends React.Component {
         // well-formed document.
         svg = sanitizeSvg.sanitizeSvgText(svg);
 
-        // 4. Drop data-paper-data attributes carrying values that aren't valid
-        // JSON. Paper.js calls JSON.parse on this attribute during importSVG
-        // and synchronously throws on malformed values; one bad attribute on
-        // an unrelated element is enough to abort the whole import.
-        svg = stripInvalidPaperData(svg);
-
-        // Get the origin which the viewBox is defined relative to. During import, Paper will translate
-        // the viewBox to start at (0, 0), and we need to translate it back for some costumes to render
-        // correctly.
-        const parser = new DOMParser();
-        const svgDom = parser.parseFromString(svg, 'text/xml');
+        // 4. Parse once: read viewBox (translated back for some costumes
+        // to render correctly — paper translates it to (0, 0) on import)
+        // and strip data-paper-data values that fail JSON.parse (paper.js
+        // synchronously throws on these and aborts the whole import).
+        const svgDom = new DOMParser().parseFromString(svg, 'text/xml');
+        const modified = stripInvalidPaperData(svgDom);
         const viewBox = svgDom.documentElement.attributes.viewBox ?
             svgDom.documentElement.attributes.viewBox.value.match(/\S+/g) : null;
         if (viewBox) {
@@ -234,6 +229,7 @@ class PaperCanvas extends React.Component {
                 viewBox[i] = parseFloat(viewBox[i]);
             }
         }
+        if (modified) svg = new XMLSerializer().serializeToString(svgDom);
 
         paper.project.importSVG(svg, {
             expandShapes: true,

--- a/src/helper/strip-invalid-paper-data.js
+++ b/src/helper/strip-invalid-paper-data.js
@@ -1,0 +1,27 @@
+/**
+ * Drop `data-paper-data` attributes whose value isn't valid JSON. Paper.js
+ * synchronously calls JSON.parse on this attribute during importSVG and
+ * throws on malformed values, taking down the whole import. The attribute
+ * is paper's own serialization metadata; if it can't parse, paper wouldn't
+ * have been able to use it.
+ * @param {string} svgString - SVG markup.
+ * @returns {string} markup with invalid data-paper-data attributes removed.
+ */
+const stripInvalidPaperData = function (svgString) {
+    if (!svgString.includes('data-paper-data')) return svgString;
+    const doc = new DOMParser().parseFromString(svgString, 'text/xml');
+    let modified = false;
+    const els = doc.querySelectorAll('[data-paper-data]');
+    for (let i = 0; i < els.length; i++) {
+        try {
+            JSON.parse(els[i].getAttribute('data-paper-data'));
+        } catch {
+            els[i].removeAttribute('data-paper-data');
+            modified = true;
+        }
+    }
+    if (!modified) return svgString;
+    return new XMLSerializer().serializeToString(doc);
+};
+
+export {stripInvalidPaperData};

--- a/src/helper/strip-invalid-paper-data.js
+++ b/src/helper/strip-invalid-paper-data.js
@@ -4,14 +4,16 @@
  * throws on malformed values, taking down the whole import. The attribute
  * is paper's own serialization metadata; if it can't parse, paper wouldn't
  * have been able to use it.
- * @param {string} svgString - SVG markup.
- * @returns {string} markup with invalid data-paper-data attributes removed.
+ *
+ * Operates on a parsed Document in place so callers that already have one
+ * (e.g. for viewBox extraction) don't pay for a second parse-and-serialize.
+ * @param {Document} svgDoc - parsed SVG document; mutated in place.
+ * @returns {boolean} true if any attribute was removed (caller should
+ *   re-serialize); false if the document was untouched.
  */
-const stripInvalidPaperData = function (svgString) {
-    if (!svgString.includes('data-paper-data')) return svgString;
-    const doc = new DOMParser().parseFromString(svgString, 'text/xml');
+const stripInvalidPaperData = function (svgDoc) {
     let modified = false;
-    const els = doc.querySelectorAll('[data-paper-data]');
+    const els = svgDoc.querySelectorAll('[data-paper-data]');
     for (let i = 0; i < els.length; i++) {
         try {
             JSON.parse(els[i].getAttribute('data-paper-data'));
@@ -20,8 +22,7 @@ const stripInvalidPaperData = function (svgString) {
             modified = true;
         }
     }
-    if (!modified) return svgString;
-    return new XMLSerializer().serializeToString(doc);
+    return modified;
 };
 
 export {stripInvalidPaperData};

--- a/test/fixtures/invalid-paper-data.svg
+++ b/test/fixtures/invalid-paper-data.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100" data-paper-data="not valid json">
+    <g data-paper-data='{"isPaintingLayer":false}'>
+        <circle cx="50" cy="50" r="40" fill="red"/>
+    </g>
+</svg>

--- a/test/unit/svg-round-trip.test.js
+++ b/test/unit/svg-round-trip.test.js
@@ -3,6 +3,8 @@ import fs from 'fs';
 import path from 'path';
 import paper from '@scratch/paper';
 
+import {stripInvalidPaperData} from '../../src/helper/strip-invalid-paper-data';
+
 /**
  * Walk a paper item and produce a normalized structural snapshot mirroring
  * the fields the editor's selection and grouping tools care about:
@@ -114,11 +116,43 @@ describe('Paper.js JSON round-trip preserves editor-relevant scene-graph (Phase 
         // Guard against a trivially-passing test: the cat costume has
         // multiple groups and a bunch of paths.
         const beforeKinds = tallyItemKinds(before.layers);
-        expect(beforeKinds.Path || 0).toBeGreaterThan(0);
-        expect(beforeKinds.Group || 0).toBeGreaterThan(0);
+        expect(beforeKinds.Path).toBeGreaterThan(0);
+        expect(beforeKinds.Group).toBeGreaterThan(0);
 
         // Deep equality covers item count, hierarchy, kind, and any name /
         // dataId that paper does happen to carry through.
+        expect(after).toEqual(before);
+    });
+
+    test('invalid-paper-data fixture: bad data-paper-data is stripped, valid content survives round-trip', () => {
+        // The fixture has data-paper-data="not valid json" on the <svg>
+        // root and a valid data-paper-data on a <g> wrapping a <circle>.
+        // Without the strip, paper.project.importSVG synchronously throws
+        // on the bad attribute and the import never reaches the circle.
+        const svgPath = path.resolve(__dirname, '..', 'fixtures', 'invalid-paper-data.svg');
+        const raw = fs.readFileSync(svgPath, 'utf8');
+        const rawDoc = new DOMParser().parseFromString(raw, 'text/xml');
+        expect(rawDoc.documentElement.getAttribute('data-paper-data')).toBe('not valid json');
+
+        const stripped = stripInvalidPaperData(raw);
+        const strippedDoc = new DOMParser().parseFromString(stripped, 'text/xml');
+
+        // Bad attribute on the root is gone; valid sibling on <g> remains.
+        expect(strippedDoc.documentElement.hasAttribute('data-paper-data')).toBe(false);
+        const g = strippedDoc.querySelector('g');
+        expect(g).not.toBeNull();
+        expect(JSON.parse(g.getAttribute('data-paper-data'))).toEqual({isPaintingLayer: false});
+
+        // Circle still present in the markup paper will receive.
+        expect(strippedDoc.querySelector('circle')).not.toBeNull();
+
+        const {before, after} = roundTripSceneGraphs(stripped);
+
+        // <circle> with expandShapes: true becomes a Path. If paper had
+        // thrown on the bad attribute, no Path would be present here.
+        const beforeKinds = tallyItemKinds(before.layers);
+        expect(beforeKinds.Path).toBeGreaterThan(0);
+
         expect(after).toEqual(before);
     });
 });

--- a/test/unit/svg-round-trip.test.js
+++ b/test/unit/svg-round-trip.test.js
@@ -131,21 +131,21 @@ describe('Paper.js JSON round-trip preserves editor-relevant scene-graph (Phase 
         // on the bad attribute and the import never reaches the circle.
         const svgPath = path.resolve(__dirname, '..', 'fixtures', 'invalid-paper-data.svg');
         const raw = fs.readFileSync(svgPath, 'utf8');
-        const rawDoc = new DOMParser().parseFromString(raw, 'text/xml');
-        expect(rawDoc.documentElement.getAttribute('data-paper-data')).toBe('not valid json');
+        const doc = new DOMParser().parseFromString(raw, 'text/xml');
+        expect(doc.documentElement.getAttribute('data-paper-data')).toBe('not valid json');
 
-        const stripped = stripInvalidPaperData(raw);
-        const strippedDoc = new DOMParser().parseFromString(stripped, 'text/xml');
+        expect(stripInvalidPaperData(doc)).toBe(true);
 
         // Bad attribute on the root is gone; valid sibling on <g> remains.
-        expect(strippedDoc.documentElement.hasAttribute('data-paper-data')).toBe(false);
-        const g = strippedDoc.querySelector('g');
+        expect(doc.documentElement.hasAttribute('data-paper-data')).toBe(false);
+        const g = doc.querySelector('g');
         expect(g).not.toBeNull();
         expect(JSON.parse(g.getAttribute('data-paper-data'))).toEqual({isPaintingLayer: false});
 
         // Circle still present in the markup paper will receive.
-        expect(strippedDoc.querySelector('circle')).not.toBeNull();
+        expect(doc.querySelector('circle')).not.toBeNull();
 
+        const stripped = new XMLSerializer().serializeToString(doc);
         const {before, after} = roundTripSceneGraphs(stripped);
 
         // <circle> with expandShapes: true becomes a Path. If paper had


### PR DESCRIPTION
### Resolves

`paper.project.importSVG` synchronously calls `JSON.parse` on every `data-paper-data` attribute it encounters, and synchronously throws on malformed values. One bad attribute on an unrelated element is enough to abort the entire SVG import — for example, an SVG with `data-paper-data="any invalid JSON"` on the `<svg>` root will never reach the `<path>` children.

### Proposed Changes

- New helper `src/helper/strip-invalid-paper-data.js`: parses the SVG, walks `[data-paper-data]`, attempts `JSON.parse` on each value, and removes the attribute if parsing fails. Re-serializes only when something was modified.
- `src/containers/paper-canvas.jsx`: in `importSvg`, between `sanitizeSvg.sanitizeSvgText(svg)` and `paper.project.importSVG`, run the SVG through the new helper.
- New `test/fixtures/invalid-paper-data.svg`: minimal fixture with a bad `data-paper-data="not valid json"` on the `<svg>` root, a valid `data-paper-data='{"isPaintingLayer":false}'` on a `<g>`, and a `<circle>` inside.
- `test/unit/svg-round-trip.test.js`: new test exercising the helper + paper round-trip on the fixture. DOMParser-based assertions verify the bad attribute is gone, the valid sibling survives untouched, and the `<circle>` is still present in the markup paper receives. Also drops the `|| 0` redundancy from the existing `expect(beforeKinds.X || 0).toBeGreaterThan(0)` guards (the count is always either a positive integer or absent; `|| 0` adds nothing).

### Reason for Changes

The narrow scope (strip only when `JSON.parse` fails) preserves paper.js's normal serialization round-trip for `item.data`. scratch-paint relies on at least one round-tripped flag (`data.isPGTextItem`, read in `helper/item.js`, `selection.js`, `scale-tool.js`, `group.js`) for legacy text-item handling — blanket-stripping `data-paper-data` would silently change behavior for projects in the wild that carry that flag.

### Test Coverage

- `npx jest test/unit/svg-round-trip.test.js` — 2 passed (cat costume + new fixture).
- `npx jest` — 57 passed across 12 suites.
- Verified out of band that without the strip, `paper.project.importSVG` throws `SyntaxError: ... "not valid json" is not valid JSON` on the new fixture, so the test catches a real regression rather than passing trivially.